### PR TITLE
enable/disable buttons according to min/max

### DIFF
--- a/library/src/com/doomonafireball/betterpickers/numberpicker/NumberPicker.java
+++ b/library/src/com/doomonafireball/betterpickers/numberpicker/NumberPicker.java
@@ -306,13 +306,13 @@ public class NumberPicker extends LinearLayout implements Button.OnClickListener
             return;
         }
 
-        double enteredNumber = getEnteredNumber();
         if (containsDecimal()) {
+            double enteredNumber = getEnteredNumber();
             int minKey = 0;
             int maxKey = (enteredNumber < mMaxNumber)? 9 : 0;
             setKeyRange(minKey, maxKey);
         } else {
-            int number = (int) getEnteredNumber();
+            int number = getNumber();
             if (number == 0) {
                 int minKey = (getEnteredNumberString().equals("") && mMaxNumber >= 0 && mMinNumber <= 0)? 0 : 1;
                 int maxKey = mMaxNumber <= 9 ? mMaxNumber : 9;


### PR DESCRIPTION
Working:
- disable right button when making the number decimal would exceed max
- disable left button when the inverted number would exceed min/max

Works only for positive numbers and when both min and max are set:
- disable 0 when number is empty and min is greater than 0
- disable number button when adding the number would exceed max

Maybe we could either have defaults for min/max or merge the setMin()/setMax methods.
