### PR TITLE
Remove addToBackStack(null) in Fragment samples which causes a blank screen when pressing the back button

### DIFF
--- a/sample/src/com/doomonafireball/betterpickers/sample/activity/SampleDateUsingFragment.java
+++ b/sample/src/com/doomonafireball/betterpickers/sample/activity/SampleDateUsingFragment.java
@@ -21,7 +21,6 @@ public class SampleDateUsingFragment extends BaseSampleActivity {
         FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
 
         transaction.replace(R.id.frame, fragment);
-        transaction.addToBackStack(null);
 
         transaction.commit();
     }

--- a/sample/src/com/doomonafireball/betterpickers/sample/activity/SampleHmsUsingFragment.java
+++ b/sample/src/com/doomonafireball/betterpickers/sample/activity/SampleHmsUsingFragment.java
@@ -21,7 +21,6 @@ public class SampleHmsUsingFragment extends BaseSampleActivity {
         FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
 
         transaction.replace(R.id.frame, fragment);
-        transaction.addToBackStack(null);
 
         transaction.commit();
     }

--- a/sample/src/com/doomonafireball/betterpickers/sample/activity/SampleNumberUsingFragment.java
+++ b/sample/src/com/doomonafireball/betterpickers/sample/activity/SampleNumberUsingFragment.java
@@ -21,7 +21,6 @@ public class SampleNumberUsingFragment extends BaseSampleActivity {
         FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
 
         transaction.replace(R.id.frame, fragment);
-        transaction.addToBackStack(null);
 
         transaction.commit();
     }

--- a/sample/src/com/doomonafireball/betterpickers/sample/activity/SampleTimeUsingFragment.java
+++ b/sample/src/com/doomonafireball/betterpickers/sample/activity/SampleTimeUsingFragment.java
@@ -21,7 +21,6 @@ public class SampleTimeUsingFragment extends BaseSampleActivity {
         FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
 
         transaction.replace(R.id.frame, fragment);
-        transaction.addToBackStack(null);
 
         transaction.commit();
     }


### PR DESCRIPTION
I'm not sure if there's a reason for this line in each Fragment sample:

```
transaction.addToBackStack(null);
```

but it seems that this is causing a blank screen to be displayed when pressing the back button rather than exiting the sample. Pressing the back button again (or the up button) exits as expected.
