### PR TITLE
Change callback parameter for RadialTimePickerDialog

### DIFF
--- a/library/src/com/doomonafireball/betterpickers/radialtimepicker/RadialTimePickerDialog.java
+++ b/library/src/com/doomonafireball/betterpickers/radialtimepicker/RadialTimePickerDialog.java
@@ -114,11 +114,11 @@ public class RadialTimePickerDialog extends DialogFragment implements OnValueSel
     public interface OnTimeSetListener {
 
         /**
-         * @param view The view associated with this listener.
+         * @param RadialTimePickerDialog The view associated with this listener.
          * @param hourOfDay The hour that was set.
          * @param minute The minute that was set.
          */
-        void onTimeSet(RadialPickerLayout view, int hourOfDay, int minute);
+        void onTimeSet(RadialTimePickerDialog dialog, int hourOfDay, int minute);
     }
 
     public static interface OnDialogDismissListener {
@@ -260,7 +260,7 @@ public class RadialTimePickerDialog extends DialogFragment implements OnValueSel
                     mTimePicker.tryVibrate();
                 }
                 if (mCallback != null) {
-                    mCallback.onTimeSet(mTimePicker,
+                    mCallback.onTimeSet(RadialTimePickerDialog.this,
                             mTimePicker.getHours(), mTimePicker.getMinutes());
                 }
                 dismiss();
@@ -463,7 +463,7 @@ public class RadialTimePickerDialog extends DialogFragment implements OnValueSel
                 finishKbMode(false);
             }
             if (mCallback != null) {
-                mCallback.onTimeSet(mTimePicker,
+                mCallback.onTimeSet(RadialTimePickerDialog.this,
                         mTimePicker.getHours(), mTimePicker.getMinutes());
             }
             dismiss();

--- a/sample/src/com/doomonafireball/betterpickers/sample/activity/radialtimepicker/SampleRadialTimeDefault.java
+++ b/sample/src/com/doomonafireball/betterpickers/sample/activity/radialtimepicker/SampleRadialTimeDefault.java
@@ -47,7 +47,7 @@ public class SampleRadialTimeDefault extends BaseSampleActivity
     }
 
     @Override
-    public void onTimeSet(RadialPickerLayout view, int hourOfDay, int minute) {
+    public void onTimeSet(RadialTimePickerDialog dialog, int hourOfDay, int minute) {
         text.setText("" + hourOfDay + ":" + minute);
     }
 }


### PR DESCRIPTION
The dialog (see CalendarDatePickerDialog) should be used, which allows to check the origin (with `getTag`) in the callback.
