### PR TITLE
add dark theme to calendar date picker.

### DIFF
--- a/library/res/color/calendar_date_holo_dark.xml
+++ b/library/res/color/calendar_date_holo_dark.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true" android:color="@color/darker_red"/>
+    <item android:state_pressed="false" android:state_selected="true" android:color="@color/red"/>
+    <item android:state_pressed="false" android:state_selected="false"
+        android:color="@color/white"/>
+</selector>

--- a/library/res/color/calendar_date_holo_light.xml
+++ b/library/res/color/calendar_date_holo_light.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="true" android:color="@color/darker_blue"/>
+    <item android:state_pressed="false" android:state_selected="true" android:color="@color/blue"/>
+    <item android:state_pressed="false" android:state_selected="false"
+        android:color="@color/date_picker_text_normal"/>
+</selector>

--- a/library/res/layout-land/calendar_date_picker_dialog.xml
+++ b/library/res/layout-land/calendar_date_picker_dialog.xml
@@ -39,6 +39,7 @@
         </LinearLayout>
 
         <View
+            android:id="@+id/calendar_date_picker_line"
             android:layout_width="match_parent"
             android:layout_height="1dip"
             android:background="@color/line_background" />

--- a/library/res/layout-sw600dp-land/calendar_date_picker_dialog.xml
+++ b/library/res/layout-sw600dp-land/calendar_date_picker_dialog.xml
@@ -39,6 +39,7 @@
         </LinearLayout>
 
         <View
+                android:id="@+id/calendar_date_picker_line"
                 android:layout_width="match_parent"
                 android:layout_height="1dip"
                 android:background="@color/line_background"/>

--- a/library/res/layout-sw600dp/calendar_date_picker_dialog.xml
+++ b/library/res/layout-sw600dp/calendar_date_picker_dialog.xml
@@ -34,6 +34,7 @@
     <include layout="@layout/calendar_date_picker_view_animator"/>
 
     <View
+            android:id="@+id/calendar_date_picker_line"
             android:layout_width="match_parent"
             android:layout_height="1dip"
             android:background="@color/line_background"/>

--- a/library/res/layout-w270dp-h560dp/calendar_date_picker_dialog.xml
+++ b/library/res/layout-w270dp-h560dp/calendar_date_picker_dialog.xml
@@ -34,6 +34,7 @@
     <include layout="@layout/calendar_date_picker_view_animator" />
 
     <View
+        android:id="@+id/calendar_date_picker_line"
         android:layout_width="match_parent"
         android:layout_height="1dip"
         android:background="@color/line_background" />

--- a/library/res/layout/calendar_date_picker_dialog.xml
+++ b/library/res/layout/calendar_date_picker_dialog.xml
@@ -32,6 +32,7 @@
     <include layout="@layout/calendar_date_picker_view_animator" />
 
     <View
+        android:id="@+id/calendar_date_picker_line"
         android:layout_width="@dimen/date_picker_component_width"
         android:layout_height="1dip"
         android:background="@color/line_background" />

--- a/library/res/values/colors.xml
+++ b/library/res/values/colors.xml
@@ -16,6 +16,7 @@
     <color name="default_keyboard_indicator_color_light">#ff00ddff</color>
 
     <color name="white">#ffffff</color>
+    <color name="black">#ff000000</color>
     <color name="circle_background">#f2f2f2</color>
     <color name="line_background">#cccccc</color>
     <color name="ampm_text_color">#8c8c8c</color>
@@ -36,6 +37,7 @@
 
     <!-- Colors for red theme -->
     <color name="red">#ff3333</color>
+    <color name="darker_red">#ffc92d2d</color>
     <color name="red_focused">#853333</color>
     <color name="light_gray">#404040</color>
     <color name="dark_gray">#363636</color>

--- a/library/src/com/doomonafireball/betterpickers/calendardatepicker/CalendarDatePickerDialog.java
+++ b/library/src/com/doomonafireball/betterpickers/calendardatepicker/CalendarDatePickerDialog.java
@@ -23,7 +23,9 @@ import com.doomonafireball.betterpickers.calendardatepicker.MonthAdapter.Calenda
 import com.nineoldandroids.animation.ObjectAnimator;
 
 import android.app.Activity;
+import android.content.res.ColorStateList;
 import android.content.res.Resources;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.v4.app.DialogFragment;
 import android.text.format.DateUtils;
@@ -67,6 +69,7 @@ public class CalendarDatePickerDialog extends DialogFragment implements
     private static final String KEY_YEAR_END = "year_end";
     private static final String KEY_CURRENT_VIEW = "current_view";
     private static final String KEY_LIST_POSITION_OFFSET = "list_position_offset";
+    private static final String KEY_THEME_DARK = "theme_dark";
 
     private static final int DEFAULT_START_YEAR = 1900;
     private static final int DEFAULT_END_YEAR = 2100;
@@ -107,6 +110,16 @@ public class CalendarDatePickerDialog extends DialogFragment implements
     private String mSelectDay;
     private String mYearPickerDescription;
     private String mSelectYear;
+
+    private boolean mThemeDark;
+
+    public boolean isThemeDark() {
+        return mThemeDark;
+    }
+
+    public void setThemeDark(boolean themeDark) {
+        this.mThemeDark = themeDark;
+    }
 
     /**
      * The callback used to indicate the user is done filling in the date.
@@ -179,6 +192,7 @@ public class CalendarDatePickerDialog extends DialogFragment implements
         outState.putInt(KEY_YEAR_START, mMinYear);
         outState.putInt(KEY_YEAR_END, mMaxYear);
         outState.putInt(KEY_CURRENT_VIEW, mCurrentView);
+        outState.putBoolean(KEY_THEME_DARK, mThemeDark);
         int listPosition = -1;
         if (mCurrentView == MONTH_AND_DAY_VIEW) {
             listPosition = mDayPickerView.getMostVisiblePosition();
@@ -215,6 +229,7 @@ public class CalendarDatePickerDialog extends DialogFragment implements
             currentView = savedInstanceState.getInt(KEY_CURRENT_VIEW);
             listPosition = savedInstanceState.getInt(KEY_LIST_POSITION);
             listPositionOffset = savedInstanceState.getInt(KEY_LIST_POSITION_OFFSET);
+            mThemeDark = savedInstanceState.getBoolean(KEY_THEME_DARK);
         }
 
         final Activity activity = getActivity();
@@ -266,6 +281,36 @@ public class CalendarDatePickerDialog extends DialogFragment implements
         }
 
         mHapticFeedbackController = new HapticFeedbackController(activity);
+
+        ColorStateList textColorStateList = res.getColorStateList(mThemeDark ? R.color.calendar_date_holo_dark : R.color.calendar_date_holo_light);
+
+        int lightBackground = res.getColor(mThemeDark ? R.color.light_gray : R.color.circle_background);
+        int darkBackground = res.getColor(mThemeDark ? R.color.dark_gray : R.color.white);
+        int lineBackground = res.getColor(mThemeDark ? R.color.line_dark : R.color.line_background);
+        int doneBackgroundDrawable = mThemeDark ? R.drawable.done_background_color_dark : R.drawable.done_background_color;
+
+        mDayPickerView.setThemeDark(mThemeDark);
+        mYearPickerView.setThemeDark(mThemeDark);
+
+        mYearView.setTextColor(textColorStateList);
+
+        mSelectedDayTextView.setTextColor(textColorStateList);
+        mSelectedMonthTextView.setTextColor(textColorStateList);
+
+        mYearView.setBackgroundColor(darkBackground);
+        mMonthAndDayView.setBackgroundColor(darkBackground);
+        view.setBackgroundColor(darkBackground);
+        if (mThemeDark) {
+            mDayOfWeekView.setBackgroundColor(lightBackground);
+        }
+        view.findViewById(R.id.day_picker_selected_date_layout).setBackgroundColor(darkBackground);
+
+        mYearPickerView.setBackgroundColor(lightBackground);
+        mDayPickerView.setBackgroundColor(lightBackground);
+
+        view.findViewById(R.id.calendar_date_picker_line).setBackgroundColor(lineBackground);
+        mDoneButton.setBackgroundResource(doneBackgroundDrawable);
+        mDoneButton.setTextColor(res.getColor(mThemeDark ? R.color.done_text_color_dark : R.color.done_text_color));
         return view;
     }
 

--- a/library/src/com/doomonafireball/betterpickers/calendardatepicker/CalendarDatePickerDialog.java
+++ b/library/src/com/doomonafireball/betterpickers/calendardatepicker/CalendarDatePickerDialog.java
@@ -300,7 +300,7 @@ public class CalendarDatePickerDialog extends DialogFragment implements
         mYearView.setBackgroundColor(darkBackground);
         mMonthAndDayView.setBackgroundColor(darkBackground);
         view.setBackgroundColor(darkBackground);
-        if (mThemeDark) {
+        if (mThemeDark && mDayOfWeekView != null) {
             mDayOfWeekView.setBackgroundColor(lightBackground);
         }
         view.findViewById(R.id.day_picker_selected_date_layout).setBackgroundColor(darkBackground);

--- a/library/src/com/doomonafireball/betterpickers/calendardatepicker/DayPickerView.java
+++ b/library/src/com/doomonafireball/betterpickers/calendardatepicker/DayPickerView.java
@@ -91,6 +91,9 @@ public abstract class DayPickerView extends ListView implements OnScrollListener
     private CalendarDatePickerController mController;
     private boolean mPerformingScroll;
 
+    private boolean mThemeDark = false;
+
+
     public DayPickerView(Context context, AttributeSet attrs) {
         super(context, attrs);
         init(context);
@@ -132,6 +135,7 @@ public abstract class DayPickerView extends ListView implements OnScrollListener
         } else {
             mAdapter.setSelectedDay(mSelectedDay);
         }
+        mAdapter.setThemeDark(mThemeDark);
         // refresh the view with the new parameters
         setAdapter(mAdapter);
     }
@@ -278,6 +282,17 @@ public abstract class DayPickerView extends ListView implements OnScrollListener
     }
 
     protected ScrollStateRunnable mScrollStateChangedRunnable = new ScrollStateRunnable();
+
+    public boolean isThemeDark() {
+        return mThemeDark;
+    }
+
+    public void setThemeDark(boolean ThemeDark) {
+        this.mThemeDark = ThemeDark;
+        if (mAdapter != null) {
+            mAdapter.setThemeDark(mThemeDark);
+        }
+    }
 
     protected class ScrollStateRunnable implements Runnable {
 

--- a/library/src/com/doomonafireball/betterpickers/calendardatepicker/MonthAdapter.java
+++ b/library/src/com/doomonafireball/betterpickers/calendardatepicker/MonthAdapter.java
@@ -41,8 +41,14 @@ public abstract class MonthAdapter extends BaseAdapter implements OnDayClickList
 
     private CalendarDay mSelectedDay;
 
+    private boolean mThemeDark;
+
     protected static int WEEK_7_OVERHANG_HEIGHT = 7;
     protected static final int MONTHS_IN_YEAR = 12;
+
+    public void setThemeDark(boolean mThemeDark) {
+        this.mThemeDark = mThemeDark;
+    }
 
     /**
      * A convenience class to represent a specific date.
@@ -164,6 +170,7 @@ public abstract class MonthAdapter extends BaseAdapter implements OnDayClickList
             drawingParams = (HashMap<String, Integer>) v.getTag();
         } else {
             v = createMonthView(mContext);
+            v.setThemeDark(mThemeDark);
             // Set up the new view
             LayoutParams params = new LayoutParams(
                     LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT);

--- a/library/src/com/doomonafireball/betterpickers/calendardatepicker/MonthView.java
+++ b/library/src/com/doomonafireball/betterpickers/calendardatepicker/MonthView.java
@@ -169,6 +169,7 @@ public abstract class MonthView extends View {
     private final Calendar mCalendar;
     private final Calendar mDayLabelCalendar;
     private final MonthViewTouchHelper mTouchHelper;
+    private final Context mContext;
 
     private int mNumRows = DEFAULT_NUM_ROWS;
 
@@ -184,8 +185,8 @@ public abstract class MonthView extends View {
 
     public MonthView(Context context) {
         super(context);
-
-        Resources res = context.getResources();
+        mContext = context;
+        Resources res = mContext.getResources();
 
         mDayLabelCalendar = Calendar.getInstance();
         mCalendar = Calendar.getInstance();
@@ -218,6 +219,15 @@ public abstract class MonthView extends View {
         mLockAccessibilityDelegate = true;
 
         // Sets up any standard paints that will be used
+        initView();
+    }
+
+    public void setThemeDark(boolean themeDark) {
+        Resources res = mContext.getResources();
+        mDayTextColor = res.getColor(themeDark ? R.color.white : R.color.date_picker_text_normal);
+        mTodayNumberColor = res.getColor(themeDark ? R.color.red : R.color.blue);
+        mMonthTitleColor = res.getColor(R.color.white);
+        mMonthTitleBGColor = res.getColor(R.color.circle_background);
         initView();
     }
 

--- a/library/src/com/doomonafireball/betterpickers/calendardatepicker/TextViewWithCircularIndicator.java
+++ b/library/src/com/doomonafireball/betterpickers/calendardatepicker/TextViewWithCircularIndicator.java
@@ -37,7 +37,7 @@ public class TextViewWithCircularIndicator extends TextView {
     Paint mCirclePaint = new Paint();
 
     private final int mRadius;
-    private final int mCircleColor;
+    private int mCircleColor;
     private final String mItemIsSelectedText;
 
     private boolean mDrawCircle;
@@ -59,6 +59,11 @@ public class TextViewWithCircularIndicator extends TextView {
         mCirclePaint.setTextAlign(Align.CENTER);
         mCirclePaint.setStyle(Style.FILL);
         mCirclePaint.setAlpha(SELECTED_CIRCLE_ALPHA);
+    }
+
+    public void setCircleColor(int circleColor) {
+        this.mCircleColor = circleColor;
+        this.init();
     }
 
     public void drawIndicator(boolean drawCircle) {

--- a/library/src/com/doomonafireball/betterpickers/calendardatepicker/YearPickerView.java
+++ b/library/src/com/doomonafireball/betterpickers/calendardatepicker/YearPickerView.java
@@ -46,12 +46,24 @@ public class YearPickerView extends ListView implements OnItemClickListener, OnD
     private int mViewSize;
     private int mChildSize;
     private TextViewWithCircularIndicator mSelectedView;
+    private Context mContext;
+
+    private boolean mThemeDark;
+
+    public boolean isThemeDark() {
+        return mThemeDark;
+    }
+
+    public void setThemeDark(boolean themeDark) {
+        this.mThemeDark = themeDark;
+    }
 
     /**
      * @param context
      */
     public YearPickerView(Context context, CalendarDatePickerController controller) {
         super(context);
+        mContext = context;
         mController = controller;
         mController.registerOnDateChangedListener(this);
         ViewGroup.LayoutParams frame = new ViewGroup.LayoutParams(LayoutParams.MATCH_PARENT,
@@ -67,6 +79,7 @@ public class YearPickerView extends ListView implements OnItemClickListener, OnD
         setSelector(new StateListDrawable());
         setDividerHeight(0);
         onDateChanged();
+        mThemeDark = false;
     }
 
     private void init(Context context) {
@@ -113,6 +126,13 @@ public class YearPickerView extends ListView implements OnItemClickListener, OnD
                     super.getView(position, convertView, parent);
             v.requestLayout();
             int year = getYearFromTextView(v);
+            Resources res = getResources();
+
+            if (res!= null) {
+                v.setBackgroundColor(res.getColor(mThemeDark ?  R.color.light_gray : R.color.white));
+                v.setCircleColor(res.getColor(mThemeDark ? R.color.red : R.color.blue));
+                v.setTextColor(res.getColorStateList(mThemeDark ? R.color.calendar_date_holo_dark : R.color.calendar_date_holo_light));
+            }
             boolean selected = mController.getSelectedDay().year == year;
             v.drawIndicator(selected);
             if (selected) {


### PR DESCRIPTION
Tried to use the same colors as the RadialTimePicker dark theme. 
![image](https://cloud.githubusercontent.com/assets/564247/2725902/a57f1cac-c5b2-11e3-8744-9e34bebc4f88.png)

![image](https://cloud.githubusercontent.com/assets/564247/2725903/b1ae9566-c5b2-11e3-86b3-f81715d68e73.png)

The light still looks the same: 
![image](https://cloud.githubusercontent.com/assets/564247/2725860/d2bcd994-c5b1-11e3-8698-79cd5c72d770.png)

![image](https://cloud.githubusercontent.com/assets/564247/2725875/ef340174-c5b1-11e3-872a-22bfcbcdce21.png)
