### PR TITLE
Implemented custom theming for RadialTimePickerDialog with styleable

### DIFF
--- a/library/src/main/java/com/doomonafireball/betterpickers/Utils.java
+++ b/library/src/main/java/com/doomonafireball/betterpickers/Utils.java
@@ -36,9 +36,6 @@ public class Utils {
     public static final int MONDAY_BEFORE_JULIAN_EPOCH = Time.EPOCH_JULIAN_DAY - 3;
     public static final int PULSE_ANIMATOR_DURATION = 544;
 
-    // Alpha level for time picker selection.
-    public static final int SELECTED_ALPHA = 51;
-    public static final int SELECTED_ALPHA_THEME_DARK = 102;
     // Alpha level for fully opaque.
     public static final int FULL_ALPHA = 255;
 
@@ -125,7 +122,7 @@ public class Utils {
      * @return The animator object. Use .start() to begin.
      */
     public static ObjectAnimator getPulseAnimator(View labelToAnimate, float decreaseRatio,
-            float increaseRatio) {
+                                                  float increaseRatio) {
         Keyframe k0 = Keyframe.ofFloat(0f, 1f);
         Keyframe k1 = Keyframe.ofFloat(0.275f, decreaseRatio);
         Keyframe k2 = Keyframe.ofFloat(0.69f, increaseRatio);

--- a/library/src/main/java/com/doomonafireball/betterpickers/Utils.java
+++ b/library/src/main/java/com/doomonafireball/betterpickers/Utils.java
@@ -122,7 +122,7 @@ public class Utils {
      * @return The animator object. Use .start() to begin.
      */
     public static ObjectAnimator getPulseAnimator(View labelToAnimate, float decreaseRatio,
-                                                  float increaseRatio) {
+            float increaseRatio) {
         Keyframe k0 = Keyframe.ofFloat(0f, 1f);
         Keyframe k1 = Keyframe.ofFloat(0.275f, decreaseRatio);
         Keyframe k2 = Keyframe.ofFloat(0.69f, increaseRatio);

--- a/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/AmPmCirclesView.java
+++ b/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/AmPmCirclesView.java
@@ -18,6 +18,7 @@ package com.doomonafireball.betterpickers.radialtimepicker;
 
 import android.content.Context;
 import android.content.res.Resources;
+import android.content.res.TypedArray;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Paint.Align;
@@ -38,8 +39,7 @@ public class AmPmCirclesView extends View {
     private static final String TAG = "AmPmCirclesView";
 
     // Alpha level for selected circle.
-    private static final int SELECTED_ALPHA = Utils.SELECTED_ALPHA;
-    private static final int SELECTED_ALPHA_THEME_DARK = Utils.SELECTED_ALPHA_THEME_DARK;
+    private static final int SELECTED_ALPHA = 51;
 
     private final Paint mPaint = new Paint();
     private int mSelectedAlpha;
@@ -99,19 +99,12 @@ public class AmPmCirclesView extends View {
         mIsInitialized = true;
     }
 
-    /* package */ void setTheme(Context context, boolean themeDark) {
-        Resources res = context.getResources();
-        if (themeDark) {
-            mUnselectedColor = res.getColor(R.color.bpDark_gray);
-            mSelectedColor = res.getColor(R.color.bpRed);
-            mAmPmTextColor = res.getColor(R.color.bpWhite);
-            mSelectedAlpha = SELECTED_ALPHA_THEME_DARK;
-        } else {
-            mUnselectedColor = res.getColor(R.color.bpWhite);
-            mSelectedColor = res.getColor(R.color.bpBlue);
-            mAmPmTextColor = res.getColor(R.color.ampm_text_color);
-            mSelectedAlpha = SELECTED_ALPHA;
-        }
+    /* package */
+    void setTheme(TypedArray themeColors) {
+        mUnselectedColor = themeColors.getColor(R.styleable.BetterPickersTimePickerDialog_bpMainColor1, R.color.bpWhite);
+        mSelectedColor = themeColors.getColor(R.styleable.BetterPickersTimePickerDialog_bpAccentColor,R.color.bpBlue);
+        mAmPmTextColor = themeColors.getColor(R.styleable.BetterPickersTimePickerDialog_bpMainTextColor, R.color.ampm_text_color);
+        mSelectedAlpha = themeColors.getInt(R.styleable.BetterPickersTimePickerDialog_bpSelectionAlpha, 100);
     }
 
     public void setAmOrPm(int amOrPm) {

--- a/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/AmPmCirclesView.java
+++ b/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/AmPmCirclesView.java
@@ -38,9 +38,6 @@ public class AmPmCirclesView extends View {
 
     private static final String TAG = "AmPmCirclesView";
 
-    // Alpha level for selected circle.
-    private static final int SELECTED_ALPHA = 51;
-
     private final Paint mPaint = new Paint();
     private int mSelectedAlpha;
     private int mUnselectedColor;
@@ -78,7 +75,6 @@ public class AmPmCirclesView extends View {
         mUnselectedColor = res.getColor(R.color.bpWhite);
         mSelectedColor = res.getColor(R.color.bpBlue);
         mAmPmTextColor = res.getColor(R.color.ampm_text_color);
-        mSelectedAlpha = SELECTED_ALPHA;
         String typefaceFamily = res.getString(R.string.sans_serif);
         Typeface tf = Typeface.create(typefaceFamily, Typeface.NORMAL);
         mPaint.setTypeface(tf);

--- a/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/AmPmCirclesView.java
+++ b/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/AmPmCirclesView.java
@@ -97,10 +97,10 @@ public class AmPmCirclesView extends View {
 
     /* package */
     void setTheme(TypedArray themeColors) {
-        mUnselectedColor = themeColors.getColor(R.styleable.BetterPickersTimePickerDialog_bpMainColor1, R.color.bpWhite);
-        mSelectedColor = themeColors.getColor(R.styleable.BetterPickersTimePickerDialog_bpAccentColor,R.color.bpBlue);
-        mAmPmTextColor = themeColors.getColor(R.styleable.BetterPickersTimePickerDialog_bpMainTextColor, R.color.ampm_text_color);
-        mSelectedAlpha = themeColors.getInt(R.styleable.BetterPickersTimePickerDialog_bpSelectionAlpha, 100);
+        mUnselectedColor = themeColors.getColor(R.styleable.BetterPickersRadialTimePickerDialog_bpMainColor1, R.color.bpWhite);
+        mSelectedColor = themeColors.getColor(R.styleable.BetterPickersRadialTimePickerDialog_bpAccentColor,R.color.bpBlue);
+        mAmPmTextColor = themeColors.getColor(R.styleable.BetterPickersRadialTimePickerDialog_bpMainTextColor, R.color.ampm_text_color);
+        mSelectedAlpha = themeColors.getInt(R.styleable.BetterPickersRadialTimePickerDialog_bpSelectionAlpha, 100);
     }
 
     public void setAmOrPm(int amOrPm) {

--- a/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/CircleView.java
+++ b/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/CircleView.java
@@ -18,6 +18,7 @@ package com.doomonafireball.betterpickers.radialtimepicker;
 
 import android.content.Context;
 import android.content.res.Resources;
+import android.content.res.TypedArray;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.util.Log;
@@ -77,15 +78,9 @@ public class CircleView extends View {
         mIsInitialized = true;
     }
 
-    /* package */ void setTheme(Context context, boolean dark) {
-        Resources res = context.getResources();
-        if (dark) {
-            mCircleColor = res.getColor(R.color.bpDark_gray);
-            mDotColor = res.getColor(R.color.bpLight_gray);
-        } else {
-            mCircleColor = res.getColor(R.color.bpWhite);
-            mDotColor = res.getColor(R.color.numbers_text_color);
-        }
+    /* package */ void setTheme(TypedArray themeColors) {
+        mCircleColor = themeColors.getColor(R.styleable.BetterPickersTimePickerDialog_bpMainColor1, R.color.bpWhite);
+        mDotColor = themeColors.getColor(R.styleable.BetterPickersTimePickerDialog_bpMainColor2, R.color.numbers_text_color);
     }
 
     @Override

--- a/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/CircleView.java
+++ b/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/CircleView.java
@@ -79,8 +79,8 @@ public class CircleView extends View {
     }
 
     /* package */ void setTheme(TypedArray themeColors) {
-        mCircleColor = themeColors.getColor(R.styleable.BetterPickersTimePickerDialog_bpMainColor1, R.color.bpWhite);
-        mDotColor = themeColors.getColor(R.styleable.BetterPickersTimePickerDialog_bpMainColor2, R.color.numbers_text_color);
+        mCircleColor = themeColors.getColor(R.styleable.BetterPickersRadialTimePickerDialog_bpMainColor1, R.color.bpWhite);
+        mDotColor = themeColors.getColor(R.styleable.BetterPickersRadialTimePickerDialog_bpMainColor2, R.color.numbers_text_color);
     }
 
     @Override

--- a/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/RadialPickerLayout.java
+++ b/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/RadialPickerLayout.java
@@ -19,6 +19,7 @@ package com.doomonafireball.betterpickers.radialtimepicker;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.res.Resources;
+import android.content.res.TypedArray;
 import android.os.Bundle;
 import android.os.Handler;
 import android.support.v4.view.accessibility.AccessibilityManagerCompat;
@@ -162,7 +163,7 @@ public class RadialPickerLayout extends FrameLayout implements OnTouchListener {
      * Initialize the Layout with starting values.
      */
     public void initialize(Context context, HapticFeedbackController hapticFeedbackController, int initialHoursOfDay,
-            int initialMinutes, boolean is24HourMode) {
+                           int initialMinutes, boolean is24HourMode) {
         if (mTimeInitialized) {
             Log.e(TAG, "Time has already been initialized.");
             return;
@@ -213,13 +214,13 @@ public class RadialPickerLayout extends FrameLayout implements OnTouchListener {
         mTimeInitialized = true;
     }
 
-    /* package */ void setTheme(Context context, boolean themeDark) {
-        mCircleView.setTheme(context, themeDark);
-        mAmPmCirclesView.setTheme(context, themeDark);
-        mHourRadialTextsView.setTheme(context, themeDark);
-        mMinuteRadialTextsView.setTheme(context, themeDark);
-        mHourRadialSelectorView.setTheme(context, themeDark);
-        mMinuteRadialSelectorView.setTheme(context, themeDark);
+    /* package */ void setTheme(TypedArray themeColors) {
+        mCircleView.setTheme(themeColors);
+        mAmPmCirclesView.setTheme(themeColors);
+        mHourRadialTextsView.setTheme(themeColors);
+        mMinuteRadialTextsView.setTheme(themeColors);
+        mHourRadialSelectorView.setTheme(themeColors);
+        mMinuteRadialSelectorView.setTheme(themeColors);
     }
 
     public void setTime(int hours, int minutes) {
@@ -385,7 +386,7 @@ public class RadialPickerLayout extends FrameLayout implements OnTouchListener {
      * the input will be "snapped" to the closest visible degrees.
      *
      * @param degrees The input degrees
-     * @param forceAboveOrBelow The output may be forced to either the higher or lower step, or may be allowed to snap
+     * @param forceHigherOrLower The output may be forced to either the higher or lower step, or may be allowed to snap
      * to whichever is closer. Use 1 to force strictly higher, -1 to force strictly lower, and 0 to snap to the closer
      * one.
      * @return output degrees, will be a multiple of 30
@@ -425,7 +426,7 @@ public class RadialPickerLayout extends FrameLayout implements OnTouchListener {
      * @return The value that was selected, i.e. 0-23 for hours, 0-59 for minutes.
      */
     private int reselectSelector(int degrees, boolean isInnerCircle,
-            boolean forceToVisibleValue, boolean forceDrawDot) {
+                                 boolean forceToVisibleValue, boolean forceDrawDot) {
         if (degrees == -1) {
             return -1;
         }
@@ -484,7 +485,7 @@ public class RadialPickerLayout extends FrameLayout implements OnTouchListener {
      * @return Degrees from 0 to 360, if the selection was within the legal range. -1 if not.
      */
     private int getDegreesFromCoords(float pointX, float pointY, boolean forceLegal,
-            final Boolean[] isInnerCircle) {
+                                     final Boolean[] isInnerCircle) {
         int currentItem = getCurrentItemShowing();
         if (currentItem == HOUR_INDEX) {
             return mHourRadialSelectorView.getDegreesFromCoords(

--- a/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/RadialPickerLayout.java
+++ b/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/RadialPickerLayout.java
@@ -163,7 +163,7 @@ public class RadialPickerLayout extends FrameLayout implements OnTouchListener {
      * Initialize the Layout with starting values.
      */
     public void initialize(Context context, HapticFeedbackController hapticFeedbackController, int initialHoursOfDay,
-                           int initialMinutes, boolean is24HourMode) {
+            int initialMinutes, boolean is24HourMode) {
         if (mTimeInitialized) {
             Log.e(TAG, "Time has already been initialized.");
             return;
@@ -426,7 +426,7 @@ public class RadialPickerLayout extends FrameLayout implements OnTouchListener {
      * @return The value that was selected, i.e. 0-23 for hours, 0-59 for minutes.
      */
     private int reselectSelector(int degrees, boolean isInnerCircle,
-                                 boolean forceToVisibleValue, boolean forceDrawDot) {
+            boolean forceToVisibleValue, boolean forceDrawDot) {
         if (degrees == -1) {
             return -1;
         }
@@ -485,7 +485,7 @@ public class RadialPickerLayout extends FrameLayout implements OnTouchListener {
      * @return Degrees from 0 to 360, if the selection was within the legal range. -1 if not.
      */
     private int getDegreesFromCoords(float pointX, float pointY, boolean forceLegal,
-                                     final Boolean[] isInnerCircle) {
+            final Boolean[] isInnerCircle) {
         int currentItem = getCurrentItemShowing();
         if (currentItem == HOUR_INDEX) {
             return mHourRadialSelectorView.getDegreesFromCoords(

--- a/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/RadialSelectorView.java
+++ b/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/RadialSelectorView.java
@@ -91,7 +91,7 @@ public class RadialSelectorView extends View {
      * hasInnerCircle is false.
      */
     public void initialize(Context context, boolean is24HourMode, boolean hasInnerCircle,
-                           boolean disappearsOut, int selectionDegrees, boolean isInnerCircle) {
+            boolean disappearsOut, int selectionDegrees, boolean isInnerCircle) {
         if (mIsInitialized) {
             Log.e(TAG, "This RadialSelectorView may only be initialized once.");
             return;
@@ -182,7 +182,7 @@ public class RadialSelectorView extends View {
     }
 
     public int getDegreesFromCoords(float pointX, float pointY, boolean forceLegal,
-                                    final Boolean[] isInnerCircle) {
+            final Boolean[] isInnerCircle) {
         if (!mDrawValuesReady) {
             return -1;
         }

--- a/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/RadialSelectorView.java
+++ b/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/RadialSelectorView.java
@@ -18,6 +18,7 @@ package com.doomonafireball.betterpickers.radialtimepicker;
 
 import android.content.Context;
 import android.content.res.Resources;
+import android.content.res.TypedArray;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.util.Log;
@@ -39,9 +40,6 @@ public class RadialSelectorView extends View {
 
     private static final String TAG = "RadialSelectorView";
 
-    // Alpha level for selected circle.
-    private static final int SELECTED_ALPHA = Utils.SELECTED_ALPHA;
-    private static final int SELECTED_ALPHA_THEME_DARK = Utils.SELECTED_ALPHA_THEME_DARK;
     // Alpha level for the line.
     private static final int FULL_ALPHA = Utils.FULL_ALPHA;
 
@@ -93,7 +91,7 @@ public class RadialSelectorView extends View {
      * hasInnerCircle is false.
      */
     public void initialize(Context context, boolean is24HourMode, boolean hasInnerCircle,
-            boolean disappearsOut, int selectionDegrees, boolean isInnerCircle) {
+                           boolean disappearsOut, int selectionDegrees, boolean isInnerCircle) {
         if (mIsInitialized) {
             Log.e(TAG, "This RadialSelectorView may only be initialized once.");
             return;
@@ -101,10 +99,7 @@ public class RadialSelectorView extends View {
 
         Resources res = context.getResources();
 
-        int blue = res.getColor(R.color.bpBlue);
-        mPaint.setColor(blue);
         mPaint.setAntiAlias(true);
-        mSelectionAlpha = SELECTED_ALPHA;
 
         // Calculate values for the circle radius size.
         mIs24HourMode = is24HourMode;
@@ -142,17 +137,10 @@ public class RadialSelectorView extends View {
         mIsInitialized = true;
     }
 
-    /* package */ void setTheme(Context context, boolean themeDark) {
-        Resources res = context.getResources();
-        int color;
-        if (themeDark) {
-            color = res.getColor(R.color.bpRed);
-            mSelectionAlpha = SELECTED_ALPHA_THEME_DARK;
-        } else {
-            color = res.getColor(R.color.bpBlue);
-            mSelectionAlpha = SELECTED_ALPHA;
-        }
-        mPaint.setColor(color);
+    /* package */
+    void setTheme(TypedArray themeColors) {
+        mPaint.setColor(themeColors.getColor(R.styleable.BetterPickersTimePickerDialog_bpAccentColor, R.color.bpBlue));
+        mSelectionAlpha = themeColors.getInt(R.styleable.BetterPickersTimePickerDialog_bpSelectionAlpha, 51);
     }
 
     /**
@@ -194,7 +182,7 @@ public class RadialSelectorView extends View {
     }
 
     public int getDegreesFromCoords(float pointX, float pointY, boolean forceLegal,
-            final Boolean[] isInnerCircle) {
+                                    final Boolean[] isInnerCircle) {
         if (!mDrawValuesReady) {
             return -1;
         }

--- a/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/RadialSelectorView.java
+++ b/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/RadialSelectorView.java
@@ -139,8 +139,8 @@ public class RadialSelectorView extends View {
 
     /* package */
     void setTheme(TypedArray themeColors) {
-        mPaint.setColor(themeColors.getColor(R.styleable.BetterPickersTimePickerDialog_bpAccentColor, R.color.bpBlue));
-        mSelectionAlpha = themeColors.getInt(R.styleable.BetterPickersTimePickerDialog_bpSelectionAlpha, 51);
+        mPaint.setColor(themeColors.getColor(R.styleable.BetterPickersRadialTimePickerDialog_bpAccentColor, R.color.bpBlue));
+        mSelectionAlpha = themeColors.getInt(R.styleable.BetterPickersRadialTimePickerDialog_bpSelectionAlpha, 51);
     }
 
     /**

--- a/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/RadialTextsView.java
+++ b/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/RadialTextsView.java
@@ -146,7 +146,7 @@ public class RadialTextsView extends View {
     }
 
     /* package */ void setTheme(TypedArray themeColors) {
-        mPaint.setColor(themeColors.getColor(R.styleable.BetterPickersTimePickerDialog_bpMainTextColor, R.color.numbers_text_color));
+        mPaint.setColor(themeColors.getColor(R.styleable.BetterPickersRadialTimePickerDialog_bpMainTextColor, R.color.numbers_text_color));
     }
 
     /**

--- a/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/RadialTextsView.java
+++ b/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/RadialTextsView.java
@@ -18,6 +18,7 @@ package com.doomonafireball.betterpickers.radialtimepicker;
 
 import android.content.Context;
 import android.content.res.Resources;
+import android.content.res.TypedArray;
 import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.graphics.Paint.Align;
@@ -81,7 +82,7 @@ public class RadialTextsView extends View {
     }
 
     public void initialize(Resources res, String[] texts, String[] innerTexts,
-            boolean is24HourMode, boolean disappearsOut) {
+                           boolean is24HourMode, boolean disappearsOut) {
         if (mIsInitialized) {
             Log.e(TAG, "This RadialTextsView may only be initialized once.");
             return;
@@ -144,15 +145,8 @@ public class RadialTextsView extends View {
         mIsInitialized = true;
     }
 
-    /* package */ void setTheme(Context context, boolean themeDark) {
-        Resources res = context.getResources();
-        int textColor;
-        if (themeDark) {
-            textColor = res.getColor(R.color.bpWhite);
-        } else {
-            textColor = res.getColor(R.color.numbers_text_color);
-        }
-        mPaint.setColor(textColor);
+    /* package */ void setTheme(TypedArray themeColors) {
+        mPaint.setColor(themeColors.getColor(R.styleable.BetterPickersTimePickerDialog_bpMainTextColor, R.color.numbers_text_color));
     }
 
     /**
@@ -233,7 +227,7 @@ public class RadialTextsView extends View {
      * specified circle radius. Place the values in the textGridHeights and textGridWidths parameters.
      */
     private void calculateGridSizes(float numbersRadius, float xCenter, float yCenter,
-            float textSize, float[] textGridHeights, float[] textGridWidths) {
+                                    float textSize, float[] textGridHeights, float[] textGridWidths) {
         /*
          * The numbers need to be drawn in a 7x7 grid, representing the points on the Unit Circle.
          */
@@ -266,7 +260,7 @@ public class RadialTextsView extends View {
      * Draw the 12 text values at the positions specified by the textGrid parameters.
      */
     private void drawTexts(Canvas canvas, float textSize, Typeface typeface, String[] texts,
-            float[] textGridWidths, float[] textGridHeights) {
+                           float[] textGridWidths, float[] textGridHeights) {
         mPaint.setTextSize(textSize);
         mPaint.setTypeface(typeface);
         canvas.drawText(texts[0], textGridWidths[3], textGridHeights[0], mPaint);

--- a/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/RadialTextsView.java
+++ b/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/RadialTextsView.java
@@ -82,7 +82,7 @@ public class RadialTextsView extends View {
     }
 
     public void initialize(Resources res, String[] texts, String[] innerTexts,
-                           boolean is24HourMode, boolean disappearsOut) {
+            boolean is24HourMode, boolean disappearsOut) {
         if (mIsInitialized) {
             Log.e(TAG, "This RadialTextsView may only be initialized once.");
             return;
@@ -227,7 +227,7 @@ public class RadialTextsView extends View {
      * specified circle radius. Place the values in the textGridHeights and textGridWidths parameters.
      */
     private void calculateGridSizes(float numbersRadius, float xCenter, float yCenter,
-                                    float textSize, float[] textGridHeights, float[] textGridWidths) {
+            float textSize, float[] textGridHeights, float[] textGridWidths) {
         /*
          * The numbers need to be drawn in a 7x7 grid, representing the points on the Unit Circle.
          */
@@ -260,7 +260,7 @@ public class RadialTextsView extends View {
      * Draw the 12 text values at the positions specified by the textGrid parameters.
      */
     private void drawTexts(Canvas canvas, float textSize, Typeface typeface, String[] texts,
-                           float[] textGridWidths, float[] textGridHeights) {
+            float[] textGridWidths, float[] textGridHeights) {
         mPaint.setTextSize(textSize);
         mPaint.setTypeface(typeface);
         canvas.drawText(texts[0], textGridWidths[3], textGridHeights[0], mPaint);

--- a/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/RadialTimePickerDialog.java
+++ b/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/RadialTimePickerDialog.java
@@ -133,14 +133,14 @@ public class RadialTimePickerDialog extends DialogFragment implements OnValueSel
     }
 
     public static RadialTimePickerDialog newInstance(OnTimeSetListener callback,
-                                                     int hourOfDay, int minute, boolean is24HourMode) {
+            int hourOfDay, int minute, boolean is24HourMode) {
         RadialTimePickerDialog ret = new RadialTimePickerDialog();
         ret.initialize(callback, hourOfDay, minute, is24HourMode);
         return ret;
     }
 
     public void initialize(OnTimeSetListener callback,
-                           int hourOfDay, int minute, boolean is24HourMode) {
+            int hourOfDay, int minute, boolean is24HourMode) {
         mCallback = callback;
 
         mInitialHourOfDay = hourOfDay;
@@ -216,7 +216,7 @@ public class RadialTimePickerDialog extends DialogFragment implements OnValueSel
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
-                             Bundle savedInstanceState) {
+            Bundle savedInstanceState) {
         if (getShowsDialog()) {
             getDialog().getWindow().requestFeature(Window.FEATURE_NO_TITLE);
         }
@@ -474,7 +474,7 @@ public class RadialTimePickerDialog extends DialogFragment implements OnValueSel
 
     // Show either Hours or Minutes.
     private void setCurrentItemShowing(int index, boolean animateCircle, boolean delayLabelAnimate,
-                                       boolean announce) {
+            boolean announce) {
         mTimePicker.setCurrentItemShowing(index, animateCircle);
 
         TextView labelToAnimate;

--- a/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/RadialTimePickerDialog.java
+++ b/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/RadialTimePickerDialog.java
@@ -20,6 +20,7 @@ import android.app.ActionBar.LayoutParams;
 import android.content.DialogInterface;
 import android.content.res.ColorStateList;
 import android.content.res.Resources;
+import android.content.res.TypedArray;
 import android.os.Bundle;
 import android.support.v4.app.DialogFragment;
 import android.util.Log;
@@ -57,7 +58,7 @@ public class RadialTimePickerDialog extends DialogFragment implements OnValueSel
     private static final String KEY_CURRENT_ITEM_SHOWING = "current_item_showing";
     private static final String KEY_IN_KB_MODE = "in_kb_mode";
     private static final String KEY_TYPED_TIMES = "typed_times";
-    private static final String KEY_DARK_THEME = "dark_theme";
+    private static final String KEY_STYLE = "theme";
 
     public static final int HOUR_INDEX = 0;
     public static final int MINUTE_INDEX = 1;
@@ -95,7 +96,7 @@ public class RadialTimePickerDialog extends DialogFragment implements OnValueSel
     private int mInitialHourOfDay;
     private int mInitialMinute;
     private boolean mIs24HourMode;
-    private boolean mThemeDark;
+    private int mStyleResId;
 
     // For hardware IME input.
     private char mPlaceholderText;
@@ -119,7 +120,7 @@ public class RadialTimePickerDialog extends DialogFragment implements OnValueSel
     public interface OnTimeSetListener {
 
         /**
-         * @param RadialTimePickerDialog The view associated with this listener.
+         * @param dialog The view associated with this listener.
          * @param hourOfDay The hour that was set.
          * @param minute The minute that was set.
          */
@@ -132,32 +133,45 @@ public class RadialTimePickerDialog extends DialogFragment implements OnValueSel
     }
 
     public static RadialTimePickerDialog newInstance(OnTimeSetListener callback,
-            int hourOfDay, int minute, boolean is24HourMode) {
+                                                     int hourOfDay, int minute, boolean is24HourMode) {
         RadialTimePickerDialog ret = new RadialTimePickerDialog();
         ret.initialize(callback, hourOfDay, minute, is24HourMode);
         return ret;
     }
 
     public void initialize(OnTimeSetListener callback,
-            int hourOfDay, int minute, boolean is24HourMode) {
+                           int hourOfDay, int minute, boolean is24HourMode) {
         mCallback = callback;
 
         mInitialHourOfDay = hourOfDay;
         mInitialMinute = minute;
         mIs24HourMode = is24HourMode;
         mInKbMode = false;
-        mThemeDark = false;
+        mStyleResId = R.style.BetterPickersTimePickerDialog;
     }
 
     /**
      * Set a dark or light theme. NOTE: this will only take effect for the next onCreateView.
      */
     public void setThemeDark(boolean dark) {
-        mThemeDark = dark;
+
+        if(dark){
+            mStyleResId = R.style.BetterPickersTimePickerDialog_Dark;
+        }else{
+            mStyleResId = R.style.BetterPickersTimePickerDialog;
+        }
+    }
+
+    /**
+     * @param styleResId a style modeled after the styleable "BetterPickersTimePickerDialog".
+     * There is an example in the android-betterpickers sample under res/values/styles.xml
+     */
+    public void setThemeCustom(int styleResId){
+        mStyleResId = styleResId;
     }
 
     public boolean isThemeDark() {
-        return mThemeDark;
+        return mStyleResId == R.style.BetterPickersTimePickerDialog_Dark;
     }
 
     public void setOnDismissListener(OnDialogDismissListener ondialogdismisslistener) {
@@ -196,13 +210,13 @@ public class RadialTimePickerDialog extends DialogFragment implements OnValueSel
             mInitialMinute = savedInstanceState.getInt(KEY_MINUTE);
             mIs24HourMode = savedInstanceState.getBoolean(KEY_IS_24_HOUR_VIEW);
             mInKbMode = savedInstanceState.getBoolean(KEY_IN_KB_MODE);
-            mThemeDark = savedInstanceState.getBoolean(KEY_DARK_THEME);
+            mStyleResId = savedInstanceState.getInt(KEY_STYLE);
         }
     }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
-            Bundle savedInstanceState) {
+                             Bundle savedInstanceState) {
         if (getShowsDialog()) {
             getDialog().getWindow().requestFeature(Window.FEATURE_NO_TITLE);
         }
@@ -212,12 +226,14 @@ public class RadialTimePickerDialog extends DialogFragment implements OnValueSel
         view.findViewById(R.id.time_picker_dialog).setOnKeyListener(keyboardListener);
 
         Resources res = getResources();
+        TypedArray themeColors = getActivity().obtainStyledAttributes(mStyleResId, R.styleable.BetterPickersTimePickerDialog);
+
         mHourPickerDescription = res.getString(R.string.hour_picker_description);
         mSelectHours = res.getString(R.string.select_hours);
         mMinutePickerDescription = res.getString(R.string.minute_picker_description);
         mSelectMinutes = res.getString(R.string.select_minutes);
-        mSelectedColor = res.getColor(mThemeDark ? R.color.bpRed : R.color.bpBlue);
-        mUnselectedColor = res.getColor(mThemeDark ? R.color.bpWhite : R.color.numbers_text_color);
+        mSelectedColor = themeColors.getColor(R.styleable.BetterPickersTimePickerDialog_bpAccentColor, R.color.bpBlue);
+        mUnselectedColor = themeColors.getColor(R.styleable.BetterPickersTimePickerDialog_bpMainTextColor, R.color.numbers_text_color);
 
         mHourView = (TextView) view.findViewById(R.id.hours);
         mHourView.setOnKeyListener(keyboardListener);
@@ -331,30 +347,25 @@ public class RadialTimePickerDialog extends DialogFragment implements OnValueSel
         }
 
         // Set the theme at the end so that the initialize()s above don't counteract the theme.
-        mTimePicker.setTheme(getActivity().getApplicationContext(), mThemeDark);
-        // Prepare some colors to use.
-        int white = res.getColor(R.color.bpWhite);
-        int circleBackground = res.getColor(R.color.circle_background);
-        int line = res.getColor(R.color.bpLine_background);
-        int timeDisplay = res.getColor(R.color.numbers_text_color);
-        ColorStateList doneTextColor = res.getColorStateList(R.color.done_text_color);
-        int doneBackground = R.drawable.done_background_color;
+        mTimePicker.setTheme(themeColors);
 
-        int darkGray = res.getColor(R.color.bpDark_gray);
-        int lightGray = res.getColor(R.color.bpLight_gray);
-        int darkLine = res.getColor(R.color.bpLine_dark);
-        ColorStateList darkDoneTextColor = res.getColorStateList(R.color.done_text_color_dark);
-        int darkDoneBackground = R.drawable.done_background_color_dark;
+        // Prepare some colors to use.
+        int mainColor1 = themeColors.getColor(R.styleable.BetterPickersTimePickerDialog_bpMainColor1, R.color.bpWhite);
+        int mainColor2 = themeColors.getColor(R.styleable.BetterPickersTimePickerDialog_bpMainColor2, R.color.circle_background);
+        int lineColor = themeColors.getColor(R.styleable.BetterPickersTimePickerDialog_bpLineColor, R.color.bpLine_background);
+        int mainTextColor = themeColors.getColor(R.styleable.BetterPickersTimePickerDialog_bpMainTextColor, R.color.numbers_text_color);
+        ColorStateList doneTextColor = themeColors.getColorStateList(R.styleable.BetterPickersTimePickerDialog_bpDoneTextColor);
+        int doneBackground = themeColors.getResourceId(R.styleable.BetterPickersTimePickerDialog_bpDoneBackgroundColor, R.drawable.done_background_color);
 
         // Set the colors for each view based on the theme.
-        view.findViewById(R.id.time_display_background).setBackgroundColor(mThemeDark ? darkGray : white);
-        view.findViewById(R.id.time_display).setBackgroundColor(mThemeDark ? darkGray : white);
-        ((TextView) view.findViewById(R.id.separator)).setTextColor(mThemeDark ? white : timeDisplay);
-        ((TextView) view.findViewById(R.id.ampm_label)).setTextColor(mThemeDark ? white : timeDisplay);
-        view.findViewById(R.id.line).setBackgroundColor(mThemeDark ? darkLine : line);
-        mDoneButton.setTextColor(mThemeDark ? darkDoneTextColor : doneTextColor);
-        mTimePicker.setBackgroundColor(mThemeDark ? lightGray : circleBackground);
-        mDoneButton.setBackgroundResource(mThemeDark ? darkDoneBackground : doneBackground);
+        view.findViewById(R.id.time_display_background).setBackgroundColor(mainColor1);
+        view.findViewById(R.id.time_display).setBackgroundColor(mainColor1);
+        ((TextView) view.findViewById(R.id.separator)).setTextColor(mainTextColor);
+        ((TextView) view.findViewById(R.id.ampm_label)).setTextColor(mainTextColor);
+        view.findViewById(R.id.line).setBackgroundColor(lineColor);
+        mDoneButton.setTextColor(doneTextColor);
+        mTimePicker.setBackgroundColor(mainColor2);
+        mDoneButton.setBackgroundResource(doneBackground);
         return view;
     }
 
@@ -399,7 +410,7 @@ public class RadialTimePickerDialog extends DialogFragment implements OnValueSel
             if (mInKbMode) {
                 outState.putIntegerArrayList(KEY_TYPED_TIMES, mTypedTimes);
             }
-            outState.putBoolean(KEY_DARK_THEME, mThemeDark);
+            outState.putInt(KEY_STYLE, mStyleResId);
         }
     }
 
@@ -463,7 +474,7 @@ public class RadialTimePickerDialog extends DialogFragment implements OnValueSel
 
     // Show either Hours or Minutes.
     private void setCurrentItemShowing(int index, boolean animateCircle, boolean delayLabelAnimate,
-            boolean announce) {
+                                       boolean announce) {
         mTimePicker.setCurrentItemShowing(index, animateCircle);
 
         TextView labelToAnimate;
@@ -658,7 +669,7 @@ public class RadialTimePickerDialog extends DialogFragment implements OnValueSel
     /**
      * Get out of keyboard mode. If there is nothing in typedTimes, revert to TimePicker's time.
      *
-     * @param changeDisplays If true, update the displays with the relevant time.
+     * @param updateDisplays If true, update the displays with the relevant time.
      */
     private void finishKbMode(boolean updateDisplays) {
         mInKbMode = false;
@@ -784,8 +795,7 @@ public class RadialTimePickerDialog extends DialogFragment implements OnValueSel
             }
         }
 
-        int[] ret = {hour, minute, amOrPm};
-        return ret;
+        return new int[]{hour, minute, amOrPm};
     }
 
     /**
@@ -998,10 +1008,7 @@ public class RadialTimePickerDialog extends DialogFragment implements OnValueSel
 
         @Override
         public boolean onKey(View v, int keyCode, KeyEvent event) {
-            if (event.getAction() == KeyEvent.ACTION_UP) {
-                return processKeyUp(keyCode);
-            }
-            return false;
+            return event.getAction() == KeyEvent.ACTION_UP && processKeyUp(keyCode);
         }
     }
 }

--- a/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/RadialTimePickerDialog.java
+++ b/library/src/main/java/com/doomonafireball/betterpickers/radialtimepicker/RadialTimePickerDialog.java
@@ -147,7 +147,7 @@ public class RadialTimePickerDialog extends DialogFragment implements OnValueSel
         mInitialMinute = minute;
         mIs24HourMode = is24HourMode;
         mInKbMode = false;
-        mStyleResId = R.style.BetterPickersTimePickerDialog;
+        mStyleResId = R.style.BetterPickersRadialTimePickerDialog;
     }
 
     /**
@@ -156,14 +156,14 @@ public class RadialTimePickerDialog extends DialogFragment implements OnValueSel
     public void setThemeDark(boolean dark) {
 
         if(dark){
-            mStyleResId = R.style.BetterPickersTimePickerDialog_Dark;
+            mStyleResId = R.style.BetterPickersRadialTimePickerDialog_Dark;
         }else{
-            mStyleResId = R.style.BetterPickersTimePickerDialog;
+            mStyleResId = R.style.BetterPickersRadialTimePickerDialog;
         }
     }
 
     /**
-     * @param styleResId a style modeled after the styleable "BetterPickersTimePickerDialog".
+     * @param styleResId a style modeled after the styleable "BetterPickersRadialTimePickerDialog".
      * There is an example in the android-betterpickers sample under res/values/styles.xml
      */
     public void setThemeCustom(int styleResId){
@@ -171,7 +171,7 @@ public class RadialTimePickerDialog extends DialogFragment implements OnValueSel
     }
 
     public boolean isThemeDark() {
-        return mStyleResId == R.style.BetterPickersTimePickerDialog_Dark;
+        return mStyleResId == R.style.BetterPickersRadialTimePickerDialog_Dark;
     }
 
     public void setOnDismissListener(OnDialogDismissListener ondialogdismisslistener) {
@@ -226,14 +226,14 @@ public class RadialTimePickerDialog extends DialogFragment implements OnValueSel
         view.findViewById(R.id.time_picker_dialog).setOnKeyListener(keyboardListener);
 
         Resources res = getResources();
-        TypedArray themeColors = getActivity().obtainStyledAttributes(mStyleResId, R.styleable.BetterPickersTimePickerDialog);
+        TypedArray themeColors = getActivity().obtainStyledAttributes(mStyleResId, R.styleable.BetterPickersRadialTimePickerDialog);
 
         mHourPickerDescription = res.getString(R.string.hour_picker_description);
         mSelectHours = res.getString(R.string.select_hours);
         mMinutePickerDescription = res.getString(R.string.minute_picker_description);
         mSelectMinutes = res.getString(R.string.select_minutes);
-        mSelectedColor = themeColors.getColor(R.styleable.BetterPickersTimePickerDialog_bpAccentColor, R.color.bpBlue);
-        mUnselectedColor = themeColors.getColor(R.styleable.BetterPickersTimePickerDialog_bpMainTextColor, R.color.numbers_text_color);
+        mSelectedColor = themeColors.getColor(R.styleable.BetterPickersRadialTimePickerDialog_bpAccentColor, R.color.bpBlue);
+        mUnselectedColor = themeColors.getColor(R.styleable.BetterPickersRadialTimePickerDialog_bpMainTextColor, R.color.numbers_text_color);
 
         mHourView = (TextView) view.findViewById(R.id.hours);
         mHourView.setOnKeyListener(keyboardListener);
@@ -350,12 +350,12 @@ public class RadialTimePickerDialog extends DialogFragment implements OnValueSel
         mTimePicker.setTheme(themeColors);
 
         // Prepare some colors to use.
-        int mainColor1 = themeColors.getColor(R.styleable.BetterPickersTimePickerDialog_bpMainColor1, R.color.bpWhite);
-        int mainColor2 = themeColors.getColor(R.styleable.BetterPickersTimePickerDialog_bpMainColor2, R.color.circle_background);
-        int lineColor = themeColors.getColor(R.styleable.BetterPickersTimePickerDialog_bpLineColor, R.color.bpLine_background);
-        int mainTextColor = themeColors.getColor(R.styleable.BetterPickersTimePickerDialog_bpMainTextColor, R.color.numbers_text_color);
-        ColorStateList doneTextColor = themeColors.getColorStateList(R.styleable.BetterPickersTimePickerDialog_bpDoneTextColor);
-        int doneBackground = themeColors.getResourceId(R.styleable.BetterPickersTimePickerDialog_bpDoneBackgroundColor, R.drawable.done_background_color);
+        int mainColor1 = themeColors.getColor(R.styleable.BetterPickersRadialTimePickerDialog_bpMainColor1, R.color.bpWhite);
+        int mainColor2 = themeColors.getColor(R.styleable.BetterPickersRadialTimePickerDialog_bpMainColor2, R.color.circle_background);
+        int lineColor = themeColors.getColor(R.styleable.BetterPickersRadialTimePickerDialog_bpLineColor, R.color.bpLine_background);
+        int mainTextColor = themeColors.getColor(R.styleable.BetterPickersRadialTimePickerDialog_bpMainTextColor, R.color.numbers_text_color);
+        ColorStateList doneTextColor = themeColors.getColorStateList(R.styleable.BetterPickersRadialTimePickerDialog_bpDoneTextColor);
+        int doneBackground = themeColors.getResourceId(R.styleable.BetterPickersRadialTimePickerDialog_bpDoneBackgroundColor, R.drawable.done_background_color);
 
         // Set the colors for each view based on the theme.
         view.findViewById(R.id.time_display_background).setBackgroundColor(mainColor1);

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -13,7 +13,7 @@
         <attr name="bpDialogBackground" format="reference"/>
     </declare-styleable>
 
-    <declare-styleable name="BetterPickersTimePickerDialog">
+    <declare-styleable name="BetterPickersRadialTimePickerDialog">
         <attr name="bpMainColor1" format="color"/>
         <attr name="bpMainColor2" format="color"/>
         <attr name="bpAccentColor" format="color"/>

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -13,6 +13,17 @@
         <attr name="bpDialogBackground" format="reference"/>
     </declare-styleable>
 
+    <declare-styleable name="BetterPickersTimePickerDialog">
+        <attr name="bpMainColor1" format="color"/>
+        <attr name="bpMainColor2" format="color"/>
+        <attr name="bpAccentColor" format="color"/>
+        <attr name="bpMainTextColor" format="color"/>
+        <attr name="bpDoneTextColor" format="color"/>
+        <attr name="bpLineColor" format="color"/>
+        <attr name="bpDoneBackgroundColor" format="color"/>
+        <attr name="bpSelectionAlpha" format="integer"/>
+    </declare-styleable>
+
     <declare-styleable name="Android">
 
         <!-- Text color. -->

--- a/library/src/main/res/values/themes.xml
+++ b/library/src/main/res/values/themes.xml
@@ -24,4 +24,25 @@
         <item name="bpDividerColor">@color/default_divider_color_light</item>
         <item name="bpKeyboardIndicatorColor">@color/default_keyboard_indicator_color_light</item>
     </style>
+
+    <style name="BetterPickersTimePickerDialog">
+        <item name="bpMainColor1">@color/bpWhite</item>
+        <item name="bpMainColor2">@color/circle_background</item>
+        <item name="bpAccentColor">@color/bpBlue</item>
+        <item name="bpMainTextColor">@color/numbers_text_color</item>
+        <item name="bpDoneTextColor">@color/done_text_color_normal</item>
+        <item name="bpLineColor">@color/bpLine_background</item>
+        <item name="bpDoneBackgroundColor">@drawable/done_background_color</item>
+        <item name="bpSelectionAlpha">51</item>
+    </style>
+    <style name="BetterPickersTimePickerDialog.Dark">
+        <item name="bpMainColor1">@color/bpDark_gray</item>
+        <item name="bpMainColor2">@color/bpLight_gray</item>
+        <item name="bpAccentColor">@color/bpRed</item>
+        <item name="bpMainTextColor">@color/bpWhite</item>
+        <item name="bpDoneTextColor">@color/bpWhite</item>
+        <item name="bpLineColor">@color/bpLine_dark</item>
+        <item name="bpDoneBackgroundColor">@drawable/done_background_color_dark</item>
+        <item name="bpSelectionAlpha">102</item>
+    </style>
 </resources>

--- a/library/src/main/res/values/themes.xml
+++ b/library/src/main/res/values/themes.xml
@@ -25,7 +25,7 @@
         <item name="bpKeyboardIndicatorColor">@color/default_keyboard_indicator_color_light</item>
     </style>
 
-    <style name="BetterPickersTimePickerDialog">
+    <style name="BetterPickersRadialTimePickerDialog">
         <item name="bpMainColor1">@color/bpWhite</item>
         <item name="bpMainColor2">@color/circle_background</item>
         <item name="bpAccentColor">@color/bpBlue</item>
@@ -35,7 +35,7 @@
         <item name="bpDoneBackgroundColor">@drawable/done_background_color</item>
         <item name="bpSelectionAlpha">51</item>
     </style>
-    <style name="BetterPickersTimePickerDialog.Dark">
+    <style name="BetterPickersRadialTimePickerDialog.Dark">
         <item name="bpMainColor1">@color/bpDark_gray</item>
         <item name="bpMainColor2">@color/bpLight_gray</item>
         <item name="bpAccentColor">@color/bpRed</item>

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -308,6 +308,14 @@
             </intent-filter>
         </activity>
         <activity
+            android:name=".activity.radialtimepicker.SampleRadialTimeCustom"
+            android:label="Radial Time/Custom">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="com.doomonafireball.betterpickers.sample.SAMPLE" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name=".activity.recurrencepicker.SampleRecurrenceDefault"
             android:label="Recurrence/Default">
             <intent-filter>

--- a/sample/src/main/java/com/doomonafireball/betterpickers/sample/activity/radialtimepicker/SampleRadialTimeCustom.java
+++ b/sample/src/main/java/com/doomonafireball/betterpickers/sample/activity/radialtimepicker/SampleRadialTimeCustom.java
@@ -1,0 +1,63 @@
+package com.doomonafireball.betterpickers.sample.activity.radialtimepicker;
+
+import android.os.Bundle;
+import android.support.v4.app.FragmentManager;
+import android.text.format.DateFormat;
+import android.view.View;
+import android.widget.Button;
+import android.widget.TextView;
+
+import com.doomonafireball.betterpickers.radialtimepicker.RadialTimePickerDialog;
+import com.doomonafireball.betterpickers.sample.R;
+import com.doomonafireball.betterpickers.sample.activity.BaseSampleActivity;
+
+import org.joda.time.DateTime;
+
+public class SampleRadialTimeCustom extends BaseSampleActivity
+        implements RadialTimePickerDialog.OnTimeSetListener {
+
+    private static final String FRAG_TAG_TIME_PICKER = "timePickerDialogFragment";
+
+    private TextView text;
+    private Button button;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.text_and_button);
+
+        text = (TextView) findViewById(R.id.text);
+        button = (Button) findViewById(R.id.button);
+
+        text.setText("--");
+        button.setText("Set Time");
+        button.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                FragmentManager fm = getSupportFragmentManager();
+                DateTime now = DateTime.now();
+                RadialTimePickerDialog timePickerDialog = RadialTimePickerDialog
+                        .newInstance(SampleRadialTimeCustom.this, now.getHourOfDay(), now.getMinuteOfHour(),
+                                DateFormat.is24HourFormat(SampleRadialTimeCustom.this));
+                timePickerDialog.setThemeCustom(R.style.MyCustomBetterPickersTimePickerDialog);
+                timePickerDialog.show(fm, FRAG_TAG_TIME_PICKER);
+            }
+        });
+    }
+
+    @Override
+    public void onTimeSet(RadialTimePickerDialog dialog, int hourOfDay, int minute) {
+        text.setText("" + hourOfDay + ":" + minute);
+    }
+
+    @Override
+    public void onResume() {
+        // Example of reattaching to the fragment
+        super.onResume();
+        RadialTimePickerDialog rtpd = (RadialTimePickerDialog) getSupportFragmentManager().findFragmentByTag(
+                FRAG_TAG_TIME_PICKER);
+        if (rtpd != null) {
+            rtpd.setOnTimeSetListener(this);
+        }
+    }
+}

--- a/sample/src/main/java/com/doomonafireball/betterpickers/sample/activity/radialtimepicker/SampleRadialTimeCustom.java
+++ b/sample/src/main/java/com/doomonafireball/betterpickers/sample/activity/radialtimepicker/SampleRadialTimeCustom.java
@@ -39,7 +39,7 @@ public class SampleRadialTimeCustom extends BaseSampleActivity
                 RadialTimePickerDialog timePickerDialog = RadialTimePickerDialog
                         .newInstance(SampleRadialTimeCustom.this, now.getHourOfDay(), now.getMinuteOfHour(),
                                 DateFormat.is24HourFormat(SampleRadialTimeCustom.this));
-                timePickerDialog.setThemeCustom(R.style.MyCustomBetterPickersTimePickerDialog);
+                timePickerDialog.setThemeCustom(R.style.MyCustomBetterPickersRadialTimePickerDialog);
                 timePickerDialog.show(fm, FRAG_TAG_TIME_PICKER);
             }
         });

--- a/sample/src/main/res/drawable/tp_done_background_color.xml
+++ b/sample/src/main/res/drawable/tp_done_background_color.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2013 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true"
+          android:state_pressed="false"
+          android:drawable="@color/custom_tp_main2" />
+
+    <item android:state_pressed="true"
+          android:drawable="@color/custom_tp_accent" />
+
+    <item android:drawable="@color/custom_tp_main1" />
+</selector>

--- a/sample/src/main/res/values/colors.xml
+++ b/sample/src/main/res/values/colors.xml
@@ -8,4 +8,10 @@
     <color name="custom_key_background">#00000000</color>
     <color name="custom_key_background_pressed">#ffcc6600</color>
     <color name="custom_keyboard_indicator_color">#ffcc6600</color>
+
+    <color name="custom_tp_main1">#d32f2f</color>
+    <color name="custom_tp_main2">#f44336</color>
+    <color name="custom_tp_accent">#ff4081</color>
+    <color name="custom_tp_text">#ffffff</color>
+    <color name="custom_tp_divider">#808080</color>
 </resources>

--- a/sample/src/main/res/values/colors.xml
+++ b/sample/src/main/res/values/colors.xml
@@ -11,7 +11,7 @@
 
     <color name="custom_tp_main1">#d32f2f</color>
     <color name="custom_tp_main2">#f44336</color>
-    <color name="custom_tp_accent">#ff4081</color>
+    <color name="custom_tp_accent">#536dfe</color>
     <color name="custom_tp_text">#ffffff</color>
     <color name="custom_tp_divider">#808080</color>
 </resources>

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -12,4 +12,15 @@
         <item name="bpDividerColor">@color/custom_divider_color</item>
         <item name="bpKeyboardIndicatorColor">@color/custom_keyboard_indicator_color</item>
     </style>
+
+    <style name="MyCustomBetterPickersTimePickerDialog">
+        <item name="bpMainColor1">@color/custom_tp_main1</item>
+        <item name="bpMainColor2">@color/custom_tp_main2</item>
+        <item name="bpAccentColor">@color/custom_tp_accent</item>
+        <item name="bpMainTextColor">@color/custom_tp_text</item>
+        <item name="bpDoneTextColor">@color/custom_tp_text</item>
+        <item name="bpLineColor">@color/custom_tp_divider</item>
+        <item name="bpDoneBackgroundColor">@drawable/tp_done_background_color</item>
+        <item name="bpSelectionAlpha">102</item>
+    </style>
 </resources>

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -13,7 +13,7 @@
         <item name="bpKeyboardIndicatorColor">@color/custom_keyboard_indicator_color</item>
     </style>
 
-    <style name="MyCustomBetterPickersTimePickerDialog">
+    <style name="MyCustomBetterPickersRadialTimePickerDialog">
         <item name="bpMainColor1">@color/custom_tp_main1</item>
         <item name="bpMainColor2">@color/custom_tp_main2</item>
         <item name="bpAccentColor">@color/custom_tp_accent</item>


### PR DESCRIPTION
Added the ability to use custom themes for RadialTimePickerDialog as requested here using styleable. All old methods work the same with RadialTimePickerDialog#setThemeCustom(int) as a new option. The sample app is also updated with an additional Radial Time demo using the new custom theme.
