### PR TITLE
Add 'year optional' parameter to DatePicker

### DIFF
--- a/library/src/main/java/com/codetroopers/betterpickers/datepicker/DatePicker.java
+++ b/library/src/main/java/com/codetroopers/betterpickers/datepicker/DatePicker.java
@@ -62,6 +62,7 @@ public class DatePicker extends LinearLayout implements Button.OnClickListener,
     private static int sYearKeyboardPosition = -1;
 
     private Button mSetButton;
+    private boolean mYearOptional = false;
 
     protected View mDivider;
     private ColorStateList mTextColor;
@@ -716,7 +717,7 @@ public class DatePicker extends LinearLayout implements Button.OnClickListener,
         if (mSetButton == null) {
             return;
         }
-        mSetButton.setEnabled(getDayOfMonth() > 0 && getYear() > 0 && getMonthOfYear() >= 0);
+        mSetButton.setEnabled(getDayOfMonth() > 0 && (mYearOptional || getYear() > 0) && getMonthOfYear() >= 0);
     }
 
     /**
@@ -799,6 +800,10 @@ public class DatePicker extends LinearLayout implements Button.OnClickListener,
             }
         }
         updateKeypad();
+    }
+
+    public void setYearOptional(boolean yearOptional) {
+        mYearOptional = yearOptional;
     }
 
     /**

--- a/library/src/main/java/com/codetroopers/betterpickers/datepicker/DatePickerBuilder.java
+++ b/library/src/main/java/com/codetroopers/betterpickers/datepicker/DatePickerBuilder.java
@@ -20,6 +20,7 @@ public class DatePickerBuilder {
     private Integer monthOfYear;
     private Integer dayOfMonth;
     private Integer year;
+    private Boolean yearOptional = false;
     private int mReference = -1;
     private Vector<DatePickerDialogHandler> mDatePickerDialogHandlers = new Vector<DatePickerDialogHandler>();
 
@@ -106,6 +107,17 @@ public class DatePickerBuilder {
     }
 
     /**
+     * Set if year should be an optional field in the picker. False by default.
+     *
+     * @param yearOptional whether the year is optional
+     * @return the current Builder object
+     */
+    public DatePickerBuilder setYearOptional(boolean yearOptional) {
+        this.yearOptional = yearOptional;
+        return this;
+    }
+
+    /**
      * Attach universal objects as additional handlers for notification when the Picker is set. For most use cases, this
      * method is not necessary as attachment to an Activity or Fragment is done automatically.  If, however, you would
      * like additional objects to subscribe to this Picker being set, attach Handlers here.
@@ -145,7 +157,7 @@ public class DatePickerBuilder {
         ft.addToBackStack(null);
 
         final DatePickerDialogFragment fragment = DatePickerDialogFragment
-                .newInstance(mReference, styleResId, monthOfYear, dayOfMonth, year);
+                .newInstance(mReference, styleResId, monthOfYear, dayOfMonth, year, yearOptional);
         if (targetFragment != null) {
             fragment.setTargetFragment(targetFragment, 0);
         }

--- a/library/src/main/java/com/codetroopers/betterpickers/datepicker/DatePickerDialogFragment.java
+++ b/library/src/main/java/com/codetroopers/betterpickers/datepicker/DatePickerDialogFragment.java
@@ -25,6 +25,7 @@ public class DatePickerDialogFragment extends DialogFragment {
     private static final String MONTH_KEY = "DatePickerDialogFragment_MonthKey";
     private static final String DAY_KEY = "DatePickerDialogFragment_DayKey";
     private static final String YEAR_KEY = "DatePickerDialogFragment_YearKey";
+    private static final String YEAR_OPTIONAL_KEY = "DatePickerDialogFragment_YearOptionalKey";
 
     private Button mSet, mCancel;
     private DatePicker mPicker;
@@ -32,6 +33,8 @@ public class DatePickerDialogFragment extends DialogFragment {
     private int mMonthOfYear = -1;
     private int mDayOfMonth = 0;
     private int mYear = 0;
+
+    private boolean mYearOptional = false;
 
     private int mReference = -1;
     private int mTheme = -1;
@@ -53,7 +56,7 @@ public class DatePickerDialogFragment extends DialogFragment {
      * @return a Picker!
      */
     public static DatePickerDialogFragment newInstance(int reference, int themeResId, Integer monthOfYear,
-            Integer dayOfMonth, Integer year) {
+            Integer dayOfMonth, Integer year, Boolean yearOptional) {
         final DatePickerDialogFragment frag = new DatePickerDialogFragment();
         Bundle args = new Bundle();
         args.putInt(REFERENCE_KEY, reference);
@@ -67,6 +70,8 @@ public class DatePickerDialogFragment extends DialogFragment {
         if (year != null) {
             args.putInt(YEAR_KEY, year);
         }
+        args.putBoolean(YEAR_OPTIONAL_KEY, yearOptional);
+
         frag.setArguments(args);
         return frag;
     }
@@ -95,6 +100,9 @@ public class DatePickerDialogFragment extends DialogFragment {
         }
         if (args != null && args.containsKey(YEAR_KEY)) {
             mYear = args.getInt(YEAR_KEY);
+        }
+        if (args != null && args.containsKey(YEAR_OPTIONAL_KEY)) {
+            mYearOptional = args.getBoolean(YEAR_OPTIONAL_KEY);
         }
 
         setStyle(DialogFragment.STYLE_NO_TITLE, 0);
@@ -135,6 +143,7 @@ public class DatePickerDialogFragment extends DialogFragment {
         mPicker = (DatePicker) v.findViewById(R.id.date_picker);
         mPicker.setSetButton(mSet);
         mPicker.setDate(mYear, mMonthOfYear, mDayOfMonth);
+        mPicker.setYearOptional(mYearOptional);
         mSet.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {


### PR DESCRIPTION
The current DatePicker implementation didn't allow to input such things as for example birthdays.
If no year is specified the DatePicker returns 0 as the year which can be easily handled.
