### PR TITLE
Specific date range in CalendarDatePickerDialog

### DIFF
--- a/library/src/main/java/com/codetroopers/betterpickers/calendardatepicker/CalendarDatePickerController.java
+++ b/library/src/main/java/com/codetroopers/betterpickers/calendardatepicker/CalendarDatePickerController.java
@@ -36,9 +36,9 @@ interface CalendarDatePickerController {
 
     int getFirstDayOfWeek();
 
-    int getMinYear();
+    CalendarDay getMinDate();
 
-    int getMaxYear();
+    CalendarDay getMaxDate();
 
     void tryVibrate();
 }

--- a/library/src/main/java/com/codetroopers/betterpickers/calendardatepicker/CalendarDatePickerDialogFragment.java
+++ b/library/src/main/java/com/codetroopers/betterpickers/calendardatepicker/CalendarDatePickerDialogFragment.java
@@ -63,13 +63,13 @@ public class CalendarDatePickerDialogFragment extends DialogFragment implements 
     private static final String KEY_SELECTED_DAY = "day";
     private static final String KEY_LIST_POSITION = "list_position";
     private static final String KEY_WEEK_START = "week_start";
-    private static final String KEY_YEAR_START = "year_start";
-    private static final String KEY_YEAR_END = "year_end";
+    private static final String KEY_DATE_START = "date_start";
+    private static final String KEY_DATE_END = "date_end";
     private static final String KEY_CURRENT_VIEW = "current_view";
     private static final String KEY_LIST_POSITION_OFFSET = "list_position_offset";
 
-    private static final int DEFAULT_START_YEAR = 1900;
-    private static final int DEFAULT_END_YEAR = 2100;
+    private static final CalendarDay DEFAULT_START_DATE = new CalendarDay(1900, Calendar.JANUARY, 1);
+    private static final CalendarDay DEFAULT_END_DATE = new CalendarDay(2100, Calendar.DECEMBER, 31);
 
     private static final int ANIMATION_DURATION = 300;
     private static final int ANIMATION_DELAY = 500;
@@ -94,9 +94,9 @@ public class CalendarDatePickerDialogFragment extends DialogFragment implements 
 
     private int mCurrentView = UNINITIALIZED;
     private int mWeekStart = mCalendar.getFirstDayOfWeek();
-    private int mMinYear = DEFAULT_START_YEAR;
+    private CalendarDay mMinDate = DEFAULT_START_DATE;
 
-    private int mMaxYear = DEFAULT_END_YEAR;
+    private CalendarDay mMaxDate = DEFAULT_END_DATE;
 
     private HapticFeedbackController mHapticFeedbackController;
 
@@ -176,8 +176,8 @@ public class CalendarDatePickerDialogFragment extends DialogFragment implements 
         outState.putInt(KEY_SELECTED_MONTH, mCalendar.get(Calendar.MONTH));
         outState.putInt(KEY_SELECTED_DAY, mCalendar.get(Calendar.DAY_OF_MONTH));
         outState.putInt(KEY_WEEK_START, mWeekStart);
-        outState.putInt(KEY_YEAR_START, mMinYear);
-        outState.putInt(KEY_YEAR_END, mMaxYear);
+        outState.putLong(KEY_DATE_START, mMinDate.getDateInMillis());
+        outState.putLong(KEY_DATE_END, mMaxDate.getDateInMillis());
         outState.putInt(KEY_CURRENT_VIEW, mCurrentView);
         int listPosition = -1;
         if (mCurrentView == MONTH_AND_DAY_VIEW) {
@@ -211,8 +211,8 @@ public class CalendarDatePickerDialogFragment extends DialogFragment implements 
         int currentView = MONTH_AND_DAY_VIEW;
         if (savedInstanceState != null) {
             mWeekStart = savedInstanceState.getInt(KEY_WEEK_START);
-            mMinYear = savedInstanceState.getInt(KEY_YEAR_START);
-            mMaxYear = savedInstanceState.getInt(KEY_YEAR_END);
+            mMinDate = new CalendarDay(savedInstanceState.getLong(KEY_DATE_START));
+            mMaxDate = new CalendarDay(savedInstanceState.getLong(KEY_DATE_END));
             currentView = savedInstanceState.getInt(KEY_CURRENT_VIEW);
             listPosition = savedInstanceState.getInt(KEY_LIST_POSITION);
             listPositionOffset = savedInstanceState.getInt(KEY_LIST_POSITION_OFFSET);
@@ -377,8 +377,21 @@ public class CalendarDatePickerDialogFragment extends DialogFragment implements 
         if (endYear <= startYear) {
             throw new IllegalArgumentException("Year end must be larger than year start");
         }
-        mMinYear = startYear;
-        mMaxYear = endYear;
+
+        mMinDate = new CalendarDay(startYear, Calendar.JANUARY, 1);
+        mMaxDate = new CalendarDay(endYear, Calendar.DECEMBER, 31);
+        if (mDayPickerView != null) {
+            mDayPickerView.onChange();
+        }
+    }
+
+    public void setDateRange(CalendarDay startDate, CalendarDay endDate) {
+        if (endDate.getDateInMillis() <= startDate.getDateInMillis()) {
+            throw new IllegalArgumentException("End date must be larger than start date");
+        }
+
+        mMinDate = startDate;
+        mMaxDate = endDate;
         if (mDayPickerView != null) {
             mDayPickerView.onChange();
         }
@@ -454,13 +467,13 @@ public class CalendarDatePickerDialogFragment extends DialogFragment implements 
     }
 
     @Override
-    public int getMinYear() {
-        return mMinYear;
+    public CalendarDay getMinDate() {
+        return mMinDate;
     }
 
     @Override
-    public int getMaxYear() {
-        return mMaxYear;
+    public CalendarDay getMaxDate() {
+        return mMaxDate;
     }
 
     @Override

--- a/library/src/main/java/com/codetroopers/betterpickers/calendardatepicker/CalendarDatePickerDialogFragment.java
+++ b/library/src/main/java/com/codetroopers/betterpickers/calendardatepicker/CalendarDatePickerDialogFragment.java
@@ -385,8 +385,16 @@ public class CalendarDatePickerDialogFragment extends DialogFragment implements 
         }
     }
 
+    /**
+     * Sets the range of the dialog to be within the specific dates. Years and months outside of the
+     * range are not shown, the days that are outside of the range are visible but cannot be selected.
+     *
+     * @param startDate The start date of the range (inclusive)
+     * @param endDate The end date of the range (inclusive)
+     * @throws IllegalArgumentException in case the end date is smaller than the start date
+     */
     public void setDateRange(CalendarDay startDate, CalendarDay endDate) {
-        if (endDate.getDateInMillis() <= startDate.getDateInMillis()) {
+        if (endDate.compareTo(startDate) < 0) {
             throw new IllegalArgumentException("End date must be larger than start date");
         }
 

--- a/library/src/main/java/com/codetroopers/betterpickers/calendardatepicker/DayPickerView.java
+++ b/library/src/main/java/com/codetroopers/betterpickers/calendardatepicker/DayPickerView.java
@@ -181,9 +181,8 @@ public abstract class DayPickerView extends ListView implements OnScrollListener
         }
 
         mTempDay.set(day);
-        final int position = (day.year - mController.getMinYear())
-                * SimpleMonthAdapter.MONTHS_IN_YEAR + day.month;
-
+        final int position = (day.year - mController.getMinDate().year) * SimpleMonthAdapter.MONTHS_IN_YEAR
+                + (day.month - mController.getMinDate().month);
         View child;
         int i = 0;
         int top = 0;
@@ -467,7 +466,7 @@ public abstract class DayPickerView extends ListView implements OnScrollListener
         // Figure out what month is showing.
         int firstVisiblePosition = getFirstVisiblePosition();
         int month = firstVisiblePosition % 12;
-        int year = firstVisiblePosition / 12 + mController.getMinYear();
+        int year = firstVisiblePosition / 12 + mController.getMinDate().year;
         CalendarDay day = new CalendarDay(year, month, 1);
 
         // Scroll either forward or backward one month.

--- a/library/src/main/java/com/codetroopers/betterpickers/calendardatepicker/MonthAdapter.java
+++ b/library/src/main/java/com/codetroopers/betterpickers/calendardatepicker/MonthAdapter.java
@@ -81,11 +81,11 @@ public abstract class MonthAdapter extends BaseAdapter implements OnDayClickList
         }
 
         public void setDay(int year, int month, int day) {
-            this.year = year;
-            this.month = month;
-            this.day = day;
             calendar = Calendar.getInstance();
             calendar.set(year, month, day, 0, 0, 0);
+            this.year = calendar.get(Calendar.YEAR);
+            this.month = calendar.get(Calendar.MONTH);
+            this.day = calendar.get(Calendar.DAY_OF_MONTH);
         }
 
         public long getDateInMillis() {

--- a/library/src/main/java/com/codetroopers/betterpickers/calendardatepicker/MonthAdapter.java
+++ b/library/src/main/java/com/codetroopers/betterpickers/calendardatepicker/MonthAdapter.java
@@ -83,6 +83,16 @@ public abstract class MonthAdapter extends BaseAdapter implements OnDayClickList
             this.year = year;
             this.month = month;
             this.day = day;
+            calendar = Calendar.getInstance();
+            calendar.set(year, month, day, 0, 0, 0);
+        }
+
+        public long getDateInMillis() {
+            if (calendar == null) {
+                calendar = Calendar.getInstance();
+                calendar.set(year, month, day, 0, 0, 0);
+            }
+            return calendar.getTimeInMillis();
         }
 
         public synchronized void setJulianDay(int julianDay) {
@@ -134,7 +144,8 @@ public abstract class MonthAdapter extends BaseAdapter implements OnDayClickList
 
     @Override
     public int getCount() {
-        return ((mController.getMaxYear() - mController.getMinYear()) + 1) * MONTHS_IN_YEAR;
+        return (((mController.getMaxDate().year - mController.getMinDate().year) + 1) * MONTHS_IN_YEAR) -
+                (MONTHS_IN_YEAR - 1 - mController.getMaxDate().month) - mController.getMinDate().month;
     }
 
     @Override
@@ -176,9 +187,8 @@ public abstract class MonthAdapter extends BaseAdapter implements OnDayClickList
         }
         drawingParams.clear();
 
-        final int month = position % MONTHS_IN_YEAR;
-        final int year = position / MONTHS_IN_YEAR + mController.getMinYear();
-
+        final int month = (position + mController.getMinDate().month) % MONTHS_IN_YEAR;
+        final int year = (position + mController.getMinDate().month)/ MONTHS_IN_YEAR + mController.getMinDate().year;
         int selectedDay = -1;
         if (isSelectedDayInMonth(year, month)) {
             selectedDay = mSelectedDay.day;

--- a/library/src/main/java/com/codetroopers/betterpickers/calendardatepicker/MonthView.java
+++ b/library/src/main/java/com/codetroopers/betterpickers/calendardatepicker/MonthView.java
@@ -97,6 +97,14 @@ public abstract class MonthView extends View {
      * If this month should display week numbers. false if 0, true otherwise.
      */
     public static final String VIEW_PARAMS_SHOW_WK_NUM = "show_wk_num";
+    /**
+     * Day in month that is the start of the selected date range. Only set if the day is in the given month
+     */
+    public static final String VIEW_PARAMS_RANGE_MIN = "range_min";
+    /**
+     * Day in month that is the end of the selected date range. Only set if the day is in the given month.
+     */
+    public static final String VIEW_PARAMS_RANGE_MAX = "range_max";
 
     protected static int DEFAULT_HEIGHT = 32;
     protected static int MIN_HEIGHT = 10;
@@ -165,7 +173,10 @@ public abstract class MonthView extends View {
     protected int mSelectedLeft = -1;
     // The right edge of the selected day
     protected int mSelectedRight = -1;
-
+    // The minimum day that fits into the provided range and is enabled.
+    protected int mRangeMin = -1;
+    // The maximum day that fits into the provided range and is enabled.
+    protected int mRangeMax = -1;
     private final Calendar mCalendar;
     private final Calendar mDayLabelCalendar;
     private final MonthViewTouchHelper mTouchHelper;
@@ -177,7 +188,8 @@ public abstract class MonthView extends View {
     // Whether to prevent setting the accessibility delegate
     private boolean mLockAccessibilityDelegate;
 
-    protected int mDayTextColor;
+    protected int mDayTextColorEnabled;
+    protected int mDayTextColorDisabled;
     protected int mTodayNumberColor;
     protected int mMonthTitleColor;
     protected int mMonthTitleBGColor;
@@ -193,7 +205,8 @@ public abstract class MonthView extends View {
         mDayOfWeekTypeface = res.getString(R.string.day_of_week_label_typeface);
         mMonthTitleTypeface = res.getString(R.string.sans_serif);
 
-        mDayTextColor = res.getColor(R.color.date_picker_text_normal);
+        mDayTextColorEnabled = res.getColor(R.color.date_picker_text_normal);
+        mDayTextColorDisabled = res.getColor(R.color.date_picker_text_disabled);
         mTodayNumberColor = res.getColor(R.color.bpBlue);
         mMonthTitleColor = res.getColor(R.color.bpWhite);
         mMonthTitleBGColor = res.getColor(R.color.circle_background);
@@ -266,7 +279,7 @@ public abstract class MonthView extends View {
         mMonthTitlePaint.setAntiAlias(true);
         mMonthTitlePaint.setTextSize(MONTH_LABEL_TEXT_SIZE);
         mMonthTitlePaint.setTypeface(Typeface.create(mMonthTitleTypeface, Typeface.BOLD));
-        mMonthTitlePaint.setColor(mDayTextColor);
+        mMonthTitlePaint.setColor(mDayTextColorEnabled);
         mMonthTitlePaint.setTextAlign(Align.CENTER);
         mMonthTitlePaint.setStyle(Style.FILL);
 
@@ -288,7 +301,7 @@ public abstract class MonthView extends View {
         mMonthDayLabelPaint = new Paint();
         mMonthDayLabelPaint.setAntiAlias(true);
         mMonthDayLabelPaint.setTextSize(MONTH_DAY_LABEL_TEXT_SIZE);
-        mMonthDayLabelPaint.setColor(mDayTextColor);
+        mMonthDayLabelPaint.setColor(mDayTextColorEnabled);
         mMonthDayLabelPaint.setTypeface(Typeface.create(mDayOfWeekTypeface, Typeface.NORMAL));
         mMonthDayLabelPaint.setStyle(Style.FILL);
         mMonthDayLabelPaint.setTextAlign(Align.CENTER);
@@ -333,6 +346,12 @@ public abstract class MonthView extends View {
         }
         if (params.containsKey(VIEW_PARAMS_SELECTED_DAY)) {
             mSelectedDay = params.get(VIEW_PARAMS_SELECTED_DAY);
+        }
+        if (params.containsKey(VIEW_PARAMS_RANGE_MIN)) {
+            mRangeMin = params.get(VIEW_PARAMS_RANGE_MIN);
+        }
+        if (params.containsKey(VIEW_PARAMS_RANGE_MAX)) {
+            mRangeMax = params.get(VIEW_PARAMS_RANGE_MAX);
         }
 
         // Allocate space for caching the day numbers and focus values
@@ -451,7 +470,7 @@ public abstract class MonthView extends View {
             int startY = y - yRelativeToDay;
             int stopY = startY + mRowHeight;
 
-            drawMonthDay(canvas, mYear, mMonth, dayNumber, x, y, startX, stopX, startY, stopY);
+            drawMonthDay(canvas, mYear, mMonth, dayNumber, x, y, startX, stopX, startY, stopY, isDayInRange(dayNumber));
 
             j++;
             if (j == mNumDays) {
@@ -459,6 +478,10 @@ public abstract class MonthView extends View {
                 y += mRowHeight;
             }
         }
+    }
+
+    private boolean isDayInRange(int day) {
+        return !(mRangeMax >= 0 && day > mRangeMax) && !(mRangeMin >= 0 && day < mRangeMin);
     }
 
     /**
@@ -474,9 +497,10 @@ public abstract class MonthView extends View {
      * @param stopX The right boundary of the day number rect
      * @param startY The top boundary of the day number rect
      * @param stopY The bottom boundary of the day number rect
+     * @param isEnabled The flag to show if the day should look enabled or not
      */
     public abstract void drawMonthDay(Canvas canvas, int year, int month, int day,
-            int x, int y, int startX, int stopX, int startY, int stopY);
+            int x, int y, int startX, int stopX, int startY, int stopY, boolean isEnabled);
 
     private int findDayOffset() {
         return (mDayOfWeekStart < mWeekStart ? (mDayOfWeekStart + mNumDays) : mDayOfWeekStart)

--- a/library/src/main/java/com/codetroopers/betterpickers/calendardatepicker/SimpleMonthView.java
+++ b/library/src/main/java/com/codetroopers/betterpickers/calendardatepicker/SimpleMonthView.java
@@ -31,7 +31,7 @@ public class SimpleMonthView extends MonthView {
 
     @Override
     public void drawMonthDay(Canvas canvas, int year, int month, int day,
-            int x, int y, int startX, int stopX, int startY, int stopY) {
+            int x, int y, int startX, int stopX, int startY, int stopY, boolean isEnabled) {
         if (mSelectedDay == day) {
             canvas.drawCircle(x, y - (MINI_DAY_NUMBER_TEXT_SIZE / 3), DAY_SELECTED_CIRCLE_SIZE,
                     mSelectedCirclePaint);
@@ -39,8 +39,10 @@ public class SimpleMonthView extends MonthView {
 
         if (mHasToday && mToday == day) {
             mMonthNumPaint.setColor(mTodayNumberColor);
+        } else if (isEnabled) {
+            mMonthNumPaint.setColor(mDayTextColorEnabled);
         } else {
-            mMonthNumPaint.setColor(mDayTextColor);
+            mMonthNumPaint.setColor(mDayTextColorDisabled);
         }
         canvas.drawText(String.format("%d", day), x, y, mMonthNumPaint);
     }

--- a/library/src/main/java/com/codetroopers/betterpickers/calendardatepicker/YearPickerView.java
+++ b/library/src/main/java/com/codetroopers/betterpickers/calendardatepicker/YearPickerView.java
@@ -71,7 +71,7 @@ public class YearPickerView extends ListView implements OnItemClickListener, OnD
 
     private void init(Context context) {
         ArrayList<String> years = new ArrayList<String>();
-        for (int year = mController.getMinYear(); year <= mController.getMaxYear(); year++) {
+        for (int year = mController.getMinDate().year; year <= mController.getMaxDate().year; year++) {
             years.add(String.format("%d", year));
         }
         mAdapter = new YearAdapter(context, R.layout.calendar_year_label_text_view, years);
@@ -148,7 +148,7 @@ public class YearPickerView extends ListView implements OnItemClickListener, OnD
     @Override
     public void onDateChanged() {
         mAdapter.notifyDataSetChanged();
-        postSetSelectionCentered(mController.getSelectedDay().year - mController.getMinYear());
+        postSetSelectionCentered(mController.getSelectedDay().year - mController.getMinDate().year);
     }
 
     @Override

--- a/library/src/main/res/values/colors.xml
+++ b/library/src/main/res/values/colors.xml
@@ -30,6 +30,7 @@
 
     <color name="neutral_pressed">#33999999</color>
     <color name="date_picker_text_normal">#ff999999</color>
+    <color name="date_picker_text_disabled">#cccccc</color>
 
     <color name="calendar_header">#999999</color>
     <color name="date_picker_view_animator">#f2f2f2</color>

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -310,6 +310,14 @@
             </intent-filter>
         </activity>
         <activity
+            android:name="com.codetroopers.betterpickers.sample.activity.calendardatepicker.SampleCalendarDateRange"
+            android:label="Calendar Date/Range">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="com.doomonafireball.betterpickers.sample.SAMPLE" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name="com.codetroopers.betterpickers.sample.activity.radialtimepicker.SampleRadialTimeDefault"
             android:label="Radial Time/Default">
             <intent-filter>

--- a/sample/src/main/java/com/codetroopers/betterpickers/sample/activity/calendardatepicker/SampleCalendarDateRange.java
+++ b/sample/src/main/java/com/codetroopers/betterpickers/sample/activity/calendardatepicker/SampleCalendarDateRange.java
@@ -1,0 +1,74 @@
+package com.codetroopers.betterpickers.sample.activity.calendardatepicker;
+
+import android.os.Bundle;
+import android.support.v4.app.FragmentManager;
+import android.view.View;
+import android.widget.Button;
+import android.widget.TextView;
+
+import com.codetroopers.betterpickers.calendardatepicker.CalendarDatePickerDialogFragment;
+import com.codetroopers.betterpickers.calendardatepicker.MonthAdapter;
+import com.codetroopers.betterpickers.sample.R;
+import com.codetroopers.betterpickers.sample.activity.BaseSampleActivity;
+
+import org.joda.time.DateTime;
+
+import java.util.Calendar;
+
+/**
+ * A copy of {@link SampleCalendarDateDefault} with added custom range using
+ * {@link CalendarDatePickerDialogFragment#setDateRange(MonthAdapter.CalendarDay, MonthAdapter.CalendarDay)}.
+ * The range is arbitrarily set from one month in the past to one month in the future from current date.
+ */
+public class SampleCalendarDateRange extends BaseSampleActivity
+        implements CalendarDatePickerDialogFragment.OnDateSetListener {
+
+    private static final String FRAG_TAG_DATE_PICKER = "fragment_date_picker_name";
+
+    private TextView text;
+    private Button button;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.text_and_button);
+
+        text = (TextView) findViewById(R.id.text);
+        button = (Button) findViewById(R.id.button);
+
+        text.setText("--");
+        button.setText("Set Date");
+        button.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                FragmentManager fm = getSupportFragmentManager();
+                DateTime now = DateTime.now();
+                CalendarDatePickerDialogFragment calendarDatePickerDialogFragment = CalendarDatePickerDialogFragment
+                        .newInstance(SampleCalendarDateRange.this, now.getYear(), now.getMonthOfYear() - 1,
+                                now.getDayOfMonth());
+
+                calendarDatePickerDialogFragment.setDateRange(
+                        new MonthAdapter.CalendarDay(now.getYear(), now.getMonthOfYear() - 2, now.getDayOfMonth()),
+                        new MonthAdapter.CalendarDay(now.getYear(), now.getMonthOfYear(), now.getDayOfMonth()));
+
+                calendarDatePickerDialogFragment.show(fm, FRAG_TAG_DATE_PICKER);
+            }
+        });
+    }
+
+    @Override
+    public void onDateSet(CalendarDatePickerDialogFragment dialog, int year, int monthOfYear, int dayOfMonth) {
+        text.setText("Year: " + year + "\nMonth: " + monthOfYear + "\nDay: " + dayOfMonth);
+    }
+
+    @Override
+    public void onResume() {
+        // Example of reattaching to the fragment
+        super.onResume();
+        CalendarDatePickerDialogFragment calendarDatePickerDialogFragment = (CalendarDatePickerDialogFragment) getSupportFragmentManager()
+                .findFragmentByTag(FRAG_TAG_DATE_PICKER);
+        if (calendarDatePickerDialogFragment != null) {
+            calendarDatePickerDialogFragment.setOnDateSetListener(this);
+        }
+    }
+}


### PR DESCRIPTION
I added a new feature, where you can set specific dates to mark the range of the CalendarDatePickerDialog by using setDateRange() method. Current version only supports setting the range in years. Behavior of the original setYearRange() method was not changed.

The behavior is the following:
- years and months that are outside of the range are not shown therefore they cannot be selected
- if the range starts/ends somewhere in the middle of a month, the whole month is shown but days that are outside of the range cannot be selected and are displayed in a disabled color
- dates that mark the range are inclusive and can be selected, so it is possible to create a range that has only one day in it
