### PR TITLE
fix for: java.lang.NullPointerException: Attempt to get length of null array

### DIFF
--- a/library/src/main/java/com/codetroopers/betterpickers/numberpicker/NumberPicker.java
+++ b/library/src/main/java/com/codetroopers/betterpickers/numberpicker/NumberPicker.java
@@ -602,15 +602,25 @@ public class NumberPicker extends LinearLayout implements Button.OnClickListener
         private SavedState(Parcel in) {
             super(in);
             mInputPointer = in.readInt();
-            in.readIntArray(mInput);
+            int size = in.readInt();
+            if (size > 0) {
+                mInput = new int[size];
+                in.readIntArray(mInput);
+            }
             mSign = in.readInt();
         }
+
 
         @Override
         public void writeToParcel(Parcel dest, int flags) {
             super.writeToParcel(dest, flags);
             dest.writeInt(mInputPointer);
-            dest.writeIntArray(mInput);
+            if (mInput != null) {
+                dest.writeInt(mInput.length);
+                dest.writeIntArray(mInput);
+            } else {
+                dest.writeInt(0);
+            }
             dest.writeInt(mSign);
         }
 


### PR DESCRIPTION
HowTo reproduce:
0) set flag don’t keep activities to true(in developers settings)
1) open any number picker
2) press home button
3) open app again
crash logs:
`
java.lang.RuntimeException: Unable to start activity ComponentInfo{com.codetroopers.betterpickersapp/com.codetroopers.betterpickers.sample.activity.numberpicker.SampleNumberBasicUsage}: java.lang.NullPointerException: Attempt to get length of null array
                                                                                     at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2416)
                                                                                     at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2476)
                                                                                     at android.app.ActivityThread.-wrap11(ActivityThread.java)
                                                                                     at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1344)
                                                                                     at android.os.Handler.dispatchMessage(Handler.java:102)
                                                                                     at android.os.Looper.loop(Looper.java:148)
                                                                                     at android.app.ActivityThread.main(ActivityThread.java:5417)
                                                                                     at java.lang.reflect.Method.invoke(Native Method)
                                                                                     at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
                                                                                     at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
                                                                                  Caused by: java.lang.NullPointerException: Attempt to get length of null array
                                                                                     at android.os.Parcel.readIntArray(Parcel.java:921)
                                                                                     at com.codetroopers.betterpickers.numberpicker.NumberPicker$SavedState.<init>(NumberPicker.java:607)
                                                                                     at com.codetroopers.betterpickers.numberpicker.NumberPicker$SavedState.<init>(NumberPicker.java:592)
                                                                                     at com.codetroopers.betterpickers.numberpicker.NumberPicker$SavedState$1.createFromParcel(NumberPicker.java:629)
                                                                                     at com.codetroopers.betterpickers.numberpicker.NumberPicker$SavedState$1.createFromParcel(NumberPicker.java:627)
                                                                                     at android.os.Parcel.readParcelable(Parcel.java:2367)
                                                                                     at android.os.Parcel.readValue(Parcel.java:2264)
                                                                                     at android.os.Parcel.readSparseArrayInternal(Parcel.java:2675)
                                                                                     at android.os.Parcel.readSparseArray(Parcel.java:1967)
                                                                                     at android.os.Parcel.readValue(Parcel.java:2321)
                                                                                     at android.os.Parcel.readArrayMapInternal(Parcel.java:2614)
                                                                                     at android.os.BaseBundle.unparcel(BaseBundle.java:221)
                                                                                     at android.os.Bundle.getSparseParcelableArray(Bundle.java:856)
                                                                                     at android.support.v4.app.FragmentManagerImpl.moveToState(FragmentManager.java:997)
                                                                                     at android.support.v4.app.FragmentManagerImpl.moveToState(FragmentManager.java:1248)
                                                                                     at android.support.v4.app.FragmentManagerImpl.moveToState(FragmentManager.java:1230)
                                                                                     at android.support.v4.app.FragmentManagerImpl.dispatchCreate(FragmentManager.java:2037)
                                                                                     at android.support.v4.app.FragmentController.dispatchCreate(FragmentController.java:154)
                                                                                     at android.support.v4.app.FragmentActivity.onCreate(FragmentActivity.java:289)
                                                                                     at android.support.v7.app.AppCompatActivity.onCreate(AppCompatActivity.java:61)
                                                                                     at com.codetroopers.betterpickers.sample.activity.BaseSampleActivity.onCreate(BaseSampleActivity.java:11)
                                                                                     at com.codetroopers.betterpickers.sample.activity.numberpicker.SampleNumberBasicUsage.onCreate(SampleNumberBasicUsage.java:26)
                                                                                     at android.app.Activity.performCreate(Activity.java:6251)
                                                                                     at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1107)
                                                                                     at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2369)
                                                                                     at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2476) 
                                                                                     at android.app.ActivityThread.-wrap11(ActivityThread.java) 
                                                                                     at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1344) 
                                                                                     at android.os.Handler.dispatchMessage(Handler.java:102) 
                                                                                     at android.os.Looper.loop(Looper.java:148) 
                                                                                     at android.app.ActivityThread.main(ActivityThread.java:5417) 
                                                                                     at java.lang.reflect.Method.invoke(Native Method) 
                                                                                     at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726) 
                                                                                     at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616) `
