### PR TITLE
Added min max limits to RadialTimePickers

### DIFF
--- a/library/src/main/java/com/codetroopers/betterpickers/radialtimepicker/RadialTimePickerDialogFragment.java
+++ b/library/src/main/java/com/codetroopers/betterpickers/radialtimepicker/RadialTimePickerDialogFragment.java
@@ -234,8 +234,9 @@ public class RadialTimePickerDialogFragment extends DialogFragment implements On
         return this;
     }
 
-    public void setTitleText(String text) {
+    public RadialTimePickerDialogFragment setTitleText(String text) {
         mTitleText = text;
+        return this;
     }
 
     public RadialTimePickerDialogFragment setDoneText(String text) {
@@ -379,8 +380,12 @@ public class RadialTimePickerDialogFragment extends DialogFragment implements On
         });
 
         mTitleTextView = (TextView) view.findViewById(R.id.time_picker_header);
-        if (mTitleTextView != null && mTitleText != null) {
+        if (mTitleText != null) {
+            mTitleTextView.setVisibility(View.VISIBLE);
             mTitleTextView.setText(mTitleText);
+        }
+        else {
+            mTitleTextView.setVisibility(View.GONE);
         }
 
         mError = (NumberPickerErrorTextView) view.findViewById(R.id.error);

--- a/library/src/main/java/com/codetroopers/betterpickers/radialtimepicker/RadialTimePickerDialogFragment.java
+++ b/library/src/main/java/com/codetroopers/betterpickers/radialtimepicker/RadialTimePickerDialogFragment.java
@@ -111,7 +111,7 @@ public class RadialTimePickerDialogFragment extends DialogFragment implements On
     private int mStyleResId;
     private Integer mFutureMinutesLimit;
     private Integer mPastMinutesLimit;
-    private Calendar mCurrentDate;
+    private Calendar mValidateDateTime;
     private Calendar mPickerDate;
 
     // For hardware IME input.
@@ -254,8 +254,8 @@ public class RadialTimePickerDialogFragment extends DialogFragment implements On
         return this;
     }
 
-    public RadialTimePickerDialogFragment setCurrentDate(Calendar currentDate) {
-        this.mCurrentDate = currentDate;
+    public RadialTimePickerDialogFragment setValidateDateTime(Calendar validateDateTime) {
+        this.mValidateDateTime = validateDateTime;
         return this;
     }
 
@@ -309,11 +309,11 @@ public class RadialTimePickerDialogFragment extends DialogFragment implements On
             mStyleResId = savedInstanceState.getInt(KEY_STYLE);
             if(savedInstanceState.containsKey(KEY_FUTURE_MINUTES_LIMIT)) mFutureMinutesLimit = savedInstanceState.getInt(KEY_FUTURE_MINUTES_LIMIT);
             if(savedInstanceState.containsKey(KEY_PAST_MINUTES_LIMIT)) mPastMinutesLimit = savedInstanceState.getInt(KEY_PAST_MINUTES_LIMIT);
-            if(savedInstanceState.containsKey(KEY_CURRENT_DATE)) mCurrentDate = (Calendar) savedInstanceState.getSerializable(KEY_CURRENT_DATE);
+            if(savedInstanceState.containsKey(KEY_CURRENT_DATE)) mValidateDateTime = (Calendar) savedInstanceState.getSerializable(KEY_CURRENT_DATE);
             if(savedInstanceState.containsKey(KEY_PICKER_DATE)) mPickerDate = (Calendar) savedInstanceState.getSerializable(KEY_PICKER_DATE);
         } else {
             if (mIs24HourMode == null) {
-                mIs24HourMode = DateFormat.is24HourFormat(getContext());
+                mIs24HourMode = DateFormat.is24HourFormat(getContext());;
             }
         }
     }
@@ -528,7 +528,7 @@ public class RadialTimePickerDialogFragment extends DialogFragment implements On
             outState.putBoolean(KEY_IN_KB_MODE, mInKbMode);
             if(mFutureMinutesLimit != null) outState.putInt(KEY_FUTURE_MINUTES_LIMIT, mFutureMinutesLimit);
             if(mPastMinutesLimit != null) outState.putInt(KEY_PAST_MINUTES_LIMIT, mPastMinutesLimit);
-            outState.putSerializable(KEY_CURRENT_DATE, mCurrentDate);
+            outState.putSerializable(KEY_CURRENT_DATE, mValidateDateTime);
             outState.putSerializable(KEY_PICKER_DATE, mPickerDate);
             if (mInKbMode) outState.putIntegerArrayList(KEY_TYPED_TIMES, mTypedTimes);
             outState.putInt(KEY_STYLE, mStyleResId);
@@ -540,14 +540,14 @@ public class RadialTimePickerDialogFragment extends DialogFragment implements On
      * @return true if too far in the future, false if not
      */
     public boolean isSelectionTooFarInTheFuture() {
-        if(this.mPickerDate != null && this.mCurrentDate != null && this.mFutureMinutesLimit != null) {
+        if(this.mPickerDate != null && this.mValidateDateTime != null && this.mFutureMinutesLimit != null) {
             Calendar selectedDate = Calendar.getInstance();
             selectedDate.setTime(this.mPickerDate.getTime());
             selectedDate.set(Calendar.HOUR_OF_DAY, mTimePicker.getHours());
             selectedDate.set(Calendar.MINUTE, mTimePicker.getMinutes());
 
             Calendar futureLimit = Calendar.getInstance();
-            futureLimit.setTime(this.mCurrentDate.getTime());
+            futureLimit.setTime(this.mValidateDateTime.getTime());
             futureLimit.add(Calendar.MINUTE, this.mFutureMinutesLimit);
             return selectedDate.compareTo(futureLimit) > 0;
         }
@@ -559,14 +559,14 @@ public class RadialTimePickerDialogFragment extends DialogFragment implements On
      * @return true if too far in the past, false if not
      */
     public boolean isSelectionTooFarInPast() {
-        if(this.mPickerDate != null && this.mCurrentDate != null && this.mPastMinutesLimit != null) {
+        if(this.mPickerDate != null && this.mValidateDateTime != null && this.mPastMinutesLimit != null) {
             Calendar selectedDate = Calendar.getInstance();
             selectedDate.setTime(this.mPickerDate.getTime());
             selectedDate.set(Calendar.HOUR_OF_DAY, mTimePicker.getHours());
             selectedDate.set(Calendar.MINUTE, mTimePicker.getMinutes());
 
             Calendar pastLimit = Calendar.getInstance();
-            pastLimit.setTime(this.mCurrentDate.getTime());
+            pastLimit.setTime(this.mValidateDateTime.getTime());
             pastLimit.add(Calendar.MINUTE, -this.mPastMinutesLimit);
             return selectedDate.compareTo(pastLimit) < 0;
         }

--- a/library/src/main/res/layout-land/radial_time_picker_dialog.xml
+++ b/library/src/main/res/layout-land/radial_time_picker_dialog.xml
@@ -27,7 +27,26 @@
     <LinearLayout
         android:layout_width="@dimen/left_side_width"
         android:layout_height="match_parent"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:background="@color/bpWhite">
+
+        <include layout="@layout/calendar_date_picker_header_view"
+            android:id="@+id/time_picker_header"
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/date_picker_header_height"/>
+
+        <com.codetroopers.betterpickers.numberpicker.NumberPickerErrorTextView
+            android:id="@+id/error"
+            android:visibility="invisible"
+            android:paddingLeft="20dp"
+            android:paddingRight="20dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
+            android:background="#ffff4444"
+            android:textColor="#ffffffff"
+            android:textStyle="bold"/>
+
         <FrameLayout
             android:id="@+id/time_display_background"
             android:layout_width="match_parent"

--- a/library/src/main/res/layout/radial_time_picker_dialog.xml
+++ b/library/src/main/res/layout/radial_time_picker_dialog.xml
@@ -20,6 +20,23 @@
     android:focusable="true"
     android:orientation="vertical">
 
+    <include layout="@layout/calendar_date_picker_header_view"
+        android:id="@+id/time_picker_header"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/date_picker_header_height" />
+
+    <com.codetroopers.betterpickers.numberpicker.NumberPickerErrorTextView
+        android:id="@+id/error"
+        android:visibility="invisible"
+        android:paddingLeft="20dp"
+        android:paddingRight="20dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:background="#ffff4444"
+        android:textColor="#ffffffff"
+        android:textStyle="bold"/>
+
     <FrameLayout
         android:id="@+id/time_display_background"
         android:layout_width="match_parent"

--- a/library/src/main/res/values-de/strings.xml
+++ b/library/src/main/res/values-de/strings.xml
@@ -29,6 +29,9 @@
     <string name="min_error">Bitte eine Zahl größer oder gleich %1$s eingeben</string>
     <string name="max_error">Bitte eine Zahl kleiner oder gleich %1$s eingeben</string>
     <string name="min_max_error">Bitte eine Zahl zwischen %1$s und %2$s eingeben</string>
+    <!-- Time validation -->
+    <string name="max_time_error">Die eingegebene Zeit liegt zu weit in der Zukunft</string>
+    <string name="min_time_error">Die eingegebene Zeit liegt zu weit in der Vergangenheit</string>
 
     <!-- From AOSP -->
     <!-- Label for button to confirm chosen date or time [CHAR LIMIT=30] -->

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -29,6 +29,9 @@
     <string name="min_error">Please input a number greater than or equal to %1$s</string>
     <string name="max_error">Please input a number less than or equal to %1$s</string>
     <string name="min_max_error">Please input a number between %1$s and %2$s</string>
+    <!-- Time validation -->
+    <string name="max_time_error">The time entered lays too far in the future</string>
+    <string name="min_time_error">The time entered lays too far in the past</string>
 
     <!-- From AOSP -->
     <!-- Label for button to confirm chosen date or time [CHAR LIMIT=30] -->

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -465,6 +465,14 @@
             </intent-filter>
         </activity>
         <activity
+            android:name=".activity.radialtimepicker.SampleRadialTimeMinMax"
+            android:label="Radial Time/Limit +-1 hour">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="com.doomonafireball.betterpickers.sample.SAMPLE" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name=".activity.recurrencepicker.SampleRecurrenceBasicUsage"
             android:label="Recurrence/Basic Usage">
             <intent-filter>

--- a/sample/src/main/java/com/codetroopers/betterpickers/sample/activity/radialtimepicker/SampleRadialTimeMinMax.java
+++ b/sample/src/main/java/com/codetroopers/betterpickers/sample/activity/radialtimepicker/SampleRadialTimeMinMax.java
@@ -1,0 +1,60 @@
+package com.codetroopers.betterpickers.sample.activity.radialtimepicker;
+
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
+import android.widget.TextView;
+
+import com.codetroopers.betterpickers.radialtimepicker.RadialTimePickerDialogFragment;
+import com.codetroopers.betterpickers.sample.R;
+import com.codetroopers.betterpickers.sample.activity.BaseSampleActivity;
+
+import java.util.Calendar;
+
+public class SampleRadialTimeMinMax extends BaseSampleActivity
+        implements RadialTimePickerDialogFragment.OnTimeSetListener {
+
+    private static final String FRAG_TAG_TIME_PICKER = "timePickerDialogFragment";
+
+    private TextView mResultTextView;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.text_and_button);
+
+        mResultTextView = (TextView) findViewById(R.id.text);
+        Button button = (Button) findViewById(R.id.button);
+
+        mResultTextView.setText(R.string.no_value);
+        button.setText(R.string.radial_time_picker);
+        button.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                RadialTimePickerDialogFragment rtpd = new RadialTimePickerDialogFragment()
+                        .setOnTimeSetListener(SampleRadialTimeMinMax.this)
+                        .setFutureMinutesLimit(60)
+                        .setPastMinutesLimit(60)
+                        .setCurrentDate(Calendar.getInstance())
+                        .setPickerDate(Calendar.getInstance())
+                        .setForced12hFormat();
+                rtpd.show(getSupportFragmentManager(), FRAG_TAG_TIME_PICKER);
+            }
+        });
+    }
+
+    @Override
+    public void onTimeSet(RadialTimePickerDialogFragment dialog, int hourOfDay, int minute) {
+        mResultTextView.setText(getString(R.string.radial_time_picker_result_value, hourOfDay, minute));
+    }
+
+    @Override
+    public void onResume() {
+        // Example of reattaching to the fragment
+        super.onResume();
+        RadialTimePickerDialogFragment rtpd = (RadialTimePickerDialogFragment) getSupportFragmentManager().findFragmentByTag(FRAG_TAG_TIME_PICKER);
+        if (rtpd != null) {
+            rtpd.setOnTimeSetListener(this);
+        }
+    }
+}

--- a/sample/src/main/java/com/codetroopers/betterpickers/sample/activity/radialtimepicker/SampleRadialTimeMinMax.java
+++ b/sample/src/main/java/com/codetroopers/betterpickers/sample/activity/radialtimepicker/SampleRadialTimeMinMax.java
@@ -35,7 +35,7 @@ public class SampleRadialTimeMinMax extends BaseSampleActivity
                         .setOnTimeSetListener(SampleRadialTimeMinMax.this)
                         .setFutureMinutesLimit(60)
                         .setPastMinutesLimit(60)
-                        .setCurrentDate(Calendar.getInstance())
+                        .setValidateDateTime(Calendar.getInstance())
                         .setPickerDate(Calendar.getInstance())
                         .setForced12hFormat();
                 rtpd.show(getSupportFragmentManager(), FRAG_TAG_TIME_PICKER);


### PR DESCRIPTION
In case you need it at some point; I made a small modification for the RadialTimePicker. It is now possible to internally set a given date context (setPickerDate) for the time picker e.g. yesterday. This can be used to validate the selected time against a date (setValidateDateTime) and a defined range in minutes (setFutureMinutesLimit and setPastMinutesLimit).
e.g. 
setPickerDate -> 20.04.2016
setValidateDateTime -> 21.04.2016 12:00
setFutureMinutesLimit -> 1440
setPastMinutesLimit -> 1440

If the time 13:00 is selected everything proceeds as usual.
If the time 11:00 is selected a warning is issued that the selected time is too far in the past.
