### PR TITLE
Added HMSPicker hour minute only option

### DIFF
--- a/library/src/main/java/com/codetroopers/betterpickers/hmspicker/HmsPicker.java
+++ b/library/src/main/java/com/codetroopers/betterpickers/hmspicker/HmsPicker.java
@@ -39,6 +39,7 @@ public class HmsPicker extends LinearLayout implements Button.OnClickListener, B
     private int mDividerColor;
     private int mDeleteDrawableSrcResId;
     private int mTheme = -1;
+    private boolean mHourMinutesOnly;
 
     /**
      * Instantiates an HmsPicker object
@@ -114,7 +115,7 @@ public class HmsPicker extends LinearLayout implements Button.OnClickListener, B
             mMinutesLabel.setTextColor(mTextColor);
             mMinutesLabel.setBackgroundResource(mKeyBackgroundResId);
         }
-        if (mSecondsLabel != null) {
+        if (mSecondsLabel != null && !mHourMinutesOnly) {
             mSecondsLabel.setTextColor(mTextColor);
             mSecondsLabel.setBackgroundResource(mKeyBackgroundResId);
         }
@@ -124,6 +125,11 @@ public class HmsPicker extends LinearLayout implements Button.OnClickListener, B
         }
         if (mEnteredHms != null) {
             mEnteredHms.setTheme(mTheme);
+
+            if(mHourMinutesOnly) {
+                mEnteredHms.setHourMinutesOnly(true);
+                mEnteredHms.rearrangeView();
+            }
         }
     }
 
@@ -249,7 +255,11 @@ public class HmsPicker extends LinearLayout implements Button.OnClickListener, B
      * Hide digit by passing -2 (for highest hours digit only);
      */
     protected void updateHms() {
-        mEnteredHms.setTime(mInput[4], mInput[3], mInput[2], mInput[1], mInput[0]);
+        if(mHourMinutesOnly) {
+            mEnteredHms.setTime(mInput[3], mInput[2], mInput[1], mInput[0], 0, 0);
+        } else {
+            mEnteredHms.setTime(0, mInput[4], mInput[3], mInput[2], mInput[1], mInput[0]);
+        }
     }
 
     private void addClickedNumber(int val) {
@@ -295,8 +305,11 @@ public class HmsPicker extends LinearLayout implements Button.OnClickListener, B
      * @return the inputted hours
      */
     public int getHours() {
-        int hours = mInput[4];
-        return hours;
+        if(mHourMinutesOnly){
+            return mInput[3] * 10 + mInput[2];
+        } else {
+            return mInput[4];
+        }
     }
 
     /**
@@ -305,7 +318,11 @@ public class HmsPicker extends LinearLayout implements Button.OnClickListener, B
      * @return the inputted minutes
      */
     public int getMinutes() {
-        return mInput[3] * 10 + mInput[2];
+        if(mHourMinutesOnly){
+            return mInput[1] * 10 + mInput[0];
+        } else {
+            return mInput[3] * 10 + mInput[2];
+        }
     }
 
     /**
@@ -314,7 +331,11 @@ public class HmsPicker extends LinearLayout implements Button.OnClickListener, B
      * @return the inputted seconds
      */
     public int getSeconds() {
-        return mInput[1] * 10 + mInput[0];
+        if(mHourMinutesOnly){
+            return 0;
+        } else {
+            return mInput[1] * 10 + mInput[0];
+        }
     }
 
     /**
@@ -325,13 +346,22 @@ public class HmsPicker extends LinearLayout implements Button.OnClickListener, B
      * @param seconds the input seconds value
      */
     public void setTime(int hours, int minutes, int seconds) {
-        mInput[4] = hours;
-        mInput[3] = minutes / 10;
-        mInput[2] = minutes % 10;
-        mInput[1] = seconds / 10;
-        mInput[0] = seconds % 10;
 
-        for (int i=4; i>=0; i--) {
+        if(mHourMinutesOnly) {
+            mInput[3] = hours / 10;
+            mInput[2] = hours % 10;
+            mInput[1] = minutes / 10;
+            mInput[0] = minutes % 10;
+
+        } else {
+            mInput[4] = hours;
+            mInput[3] = minutes / 10;
+            mInput[2] = minutes % 10;
+            mInput[1] = seconds / 10;
+            mInput[0] = seconds % 10;
+        }
+
+        for (int i=mInputSize - 1; i>=0; i--) {
             if (mInput[i] > 0) {
                 mInputPointer = i;
                 break;
@@ -413,7 +443,11 @@ public class HmsPicker extends LinearLayout implements Button.OnClickListener, B
      * @return an int representing the time in seconds
      */
     public int getTime() {
-        return mInput[4] * 3600 + mInput[3] * 600 + mInput[2] * 60 + mInput[1] * 10 + mInput[0];
+        if(mHourMinutesOnly) {
+            return mInput[3] * 36_000 +  mInput[2] * 3600 + mInput[1] * 600 + mInput[0] * 60;
+        } else {
+            return mInput[4] * 3600 + mInput[3] * 600 + mInput[2] * 60 + mInput[1] * 10 + mInput[0];
+        }
     }
 
     public void saveEntryState(Bundle outState, String key) {
@@ -439,6 +473,15 @@ public class HmsPicker extends LinearLayout implements Button.OnClickListener, B
         if (!enabled) {
             mLeft.setContentDescription(null);
             mRight.setContentDescription(null);
+        }
+    }
+
+    public void setHourMinutesOnly(boolean mHourMinutesOnly) {
+        this.mHourMinutesOnly = mHourMinutesOnly;
+        if(mHourMinutesOnly) {
+            mInputSize = 4;
+            mInput = new int[mInputSize];
+            restyleViews();
         }
     }
 }

--- a/library/src/main/java/com/codetroopers/betterpickers/hmspicker/HmsPickerBuilder.java
+++ b/library/src/main/java/com/codetroopers/betterpickers/hmspicker/HmsPickerBuilder.java
@@ -22,6 +22,12 @@ public class HmsPickerBuilder {
     private int mHours;
     private int mMinutes;
     private int mSeconds;
+    private Boolean mHourMinutesOnly;
+
+    public HmsPickerBuilder setHourMinutesOnly(boolean hourMinutesOnly){
+        this.mHourMinutesOnly = hourMinutesOnly;
+        return this;
+    }
 
     /**
      * Attach a FragmentManager. This is required for creation of the Fragment.
@@ -147,7 +153,7 @@ public class HmsPickerBuilder {
         }
         ft.addToBackStack(null);
 
-        final HmsPickerDialogFragment fragment = HmsPickerDialogFragment.newInstance(mReference, styleResId);
+        final HmsPickerDialogFragment fragment = HmsPickerDialogFragment.newInstance(mReference, styleResId, mHourMinutesOnly);
         if (targetFragment != null) {
             fragment.setTargetFragment(targetFragment, 0);
         }

--- a/library/src/main/java/com/codetroopers/betterpickers/hmspicker/HmsPickerDialogFragment.java
+++ b/library/src/main/java/com/codetroopers/betterpickers/hmspicker/HmsPickerDialogFragment.java
@@ -22,6 +22,7 @@ public class HmsPickerDialogFragment extends DialogFragment {
 
     private static final String REFERENCE_KEY = "HmsPickerDialogFragment_ReferenceKey";
     private static final String THEME_RES_ID_KEY = "HmsPickerDialogFragment_ThemeResIdKey";
+    private static final String HOUR_MINUTES_ONLY_KEY = "HmsPickerDialogFragment_HourMinutesOnly";
 
     private HmsPicker mPicker;
 
@@ -33,6 +34,7 @@ public class HmsPickerDialogFragment extends DialogFragment {
     private int mHours;
     private int mMinutes;
     private int mSeconds;
+    private boolean mHourMinutesOnly = false;
 
     /**
      * Create an instance of the Picker (used internally)
@@ -41,11 +43,14 @@ public class HmsPickerDialogFragment extends DialogFragment {
      * @param themeResId the style resource ID for theming
      * @return a Picker!
      */
-    public static HmsPickerDialogFragment newInstance(int reference, int themeResId) {
+    public static HmsPickerDialogFragment newInstance(int reference, int themeResId, Boolean hourMinutesOnly) {
         final HmsPickerDialogFragment frag = new HmsPickerDialogFragment();
         Bundle args = new Bundle();
         args.putInt(REFERENCE_KEY, reference);
         args.putInt(THEME_RES_ID_KEY, themeResId);
+        if(hourMinutesOnly != null){
+            args.putBoolean(HOUR_MINUTES_ONLY_KEY, hourMinutesOnly);
+        }
         frag.setArguments(args);
         return frag;
     }
@@ -65,6 +70,9 @@ public class HmsPickerDialogFragment extends DialogFragment {
         }
         if (args != null && args.containsKey(THEME_RES_ID_KEY)) {
             mTheme = args.getInt(THEME_RES_ID_KEY);
+        }
+        if(args != null && args.containsKey(HOUR_MINUTES_ONLY_KEY)){
+            mHourMinutesOnly = args.getBoolean(HOUR_MINUTES_ONLY_KEY);
         }
 
         setStyle(DialogFragment.STYLE_NO_TITLE, 0);
@@ -123,6 +131,7 @@ public class HmsPickerDialogFragment extends DialogFragment {
         mPicker.setSetButton(doneButton);
         mPicker.setTime(mHours, mMinutes, mSeconds);
         mPicker.setTheme(mTheme);
+        mPicker.setHourMinutesOnly(mHourMinutesOnly);
 
         getDialog().getWindow().setBackgroundDrawableResource(mDialogBackgroundResId);
 

--- a/library/src/main/java/com/codetroopers/betterpickers/hmspicker/HmsView.java
+++ b/library/src/main/java/com/codetroopers/betterpickers/hmspicker/HmsView.java
@@ -12,11 +12,12 @@ import com.codetroopers.betterpickers.widget.ZeroTopPaddingTextView;
 
 public class HmsView extends LinearLayout {
 
-    private ZeroTopPaddingTextView mHoursOnes;
+    private ZeroTopPaddingTextView mHoursOnes, mHoursTens;
     private ZeroTopPaddingTextView mMinutesOnes, mMinutesTens;
-    private ZeroTopPaddingTextView mSecondsOnes, mSecondsTens;
+    private ZeroTopPaddingTextView mSecondsOnes, mSecondsTens, mSecondsLabel;
     private final Typeface mAndroidClockMonoThin;
     private Typeface mOriginalHoursTypeface;
+    private boolean hourMinutesOnly = false;
 
     private ColorStateList mTextColor;
 
@@ -61,6 +62,9 @@ public class HmsView extends LinearLayout {
     }
 
     private void restyleViews() {
+        if (mHoursTens != null) {
+            mHoursTens.setTextColor(mTextColor);
+        }
         if (mHoursOnes != null) {
             mHoursOnes.setTextColor(mTextColor);
         }
@@ -82,29 +86,63 @@ public class HmsView extends LinearLayout {
     protected void onFinishInflate() {
         super.onFinishInflate();
 
+        mHoursTens = (ZeroTopPaddingTextView) findViewById(R.id.hours_tens);
         mHoursOnes = (ZeroTopPaddingTextView) findViewById(R.id.hours_ones);
         mMinutesTens = (ZeroTopPaddingTextView) findViewById(R.id.minutes_tens);
         mMinutesOnes = (ZeroTopPaddingTextView) findViewById(R.id.minutes_ones);
         mSecondsTens = (ZeroTopPaddingTextView) findViewById(R.id.seconds_tens);
         mSecondsOnes = (ZeroTopPaddingTextView) findViewById(R.id.seconds_ones);
+        mSecondsLabel = (ZeroTopPaddingTextView) findViewById(R.id.seconds_label);
+
+        rearrangeView();
+    }
+
+    public void rearrangeView(){
+        if (mHoursTens != null && !hourMinutesOnly) {
+            mHoursTens.setVisibility(GONE);
+        }
         if (mHoursOnes != null) {
             mOriginalHoursTypeface = mHoursOnes.getTypeface();
             mHoursOnes.updatePaddingForBoldDate();
         }
-        if (mMinutesTens != null) {
+        if (mMinutesTens != null && !hourMinutesOnly) {
             mMinutesTens.updatePaddingForBoldDate();
         }
-        if (mMinutesOnes != null) {
+        if (mMinutesOnes != null && !hourMinutesOnly) {
             mMinutesOnes.updatePaddingForBoldDate();
         }
         // Set the lowest time unit with thin font (excluding hundredths)
-        if (mSecondsTens != null) {
+        if (mSecondsTens != null && !hourMinutesOnly) {
             mSecondsTens.setTypeface(mAndroidClockMonoThin);
             mSecondsTens.updatePadding();
         }
-        if (mSecondsOnes != null) {
+        if (mSecondsOnes != null && !hourMinutesOnly) {
             mSecondsOnes.setTypeface(mAndroidClockMonoThin);
             mSecondsOnes.updatePadding();
+        }
+
+        if (mHoursTens != null && hourMinutesOnly) {
+            mHoursTens.updatePaddingForBoldDate();
+            mHoursTens.setVisibility(VISIBLE);
+        }
+
+        if (mMinutesTens != null && hourMinutesOnly) {
+            mMinutesTens.setTypeface(mAndroidClockMonoThin);
+            mMinutesTens.updatePadding();
+        }
+        if (mMinutesOnes != null && hourMinutesOnly) {
+            mMinutesOnes.setTypeface(mAndroidClockMonoThin);
+            mMinutesOnes.updatePadding();
+        }
+
+        if (mSecondsTens != null && hourMinutesOnly) {
+            mSecondsTens.setVisibility(GONE);
+        }
+        if (mSecondsOnes != null && hourMinutesOnly) {
+            mSecondsOnes.setVisibility(GONE);
+        }
+        if(mSecondsLabel != null && hourMinutesOnly){
+            mSecondsLabel.setVisibility(GONE);
         }
     }
 
@@ -117,8 +155,12 @@ public class HmsView extends LinearLayout {
      * @param secondsTensDigit the tens digit of the seconds TextView
      * @param secondsOnesDigit the ones digit of the seconds TextView
      */
-    public void setTime(int hoursOnesDigit, int minutesTensDigit, int minutesOnesDigit, int secondsTensDigit,
+    public void setTime(int hoursTensDigit, int hoursOnesDigit, int minutesTensDigit, int minutesOnesDigit, int secondsTensDigit,
             int secondsOnesDigit) {
+
+        if(mHoursTens != null){
+            mHoursTens.setText(String.format("%d", hoursTensDigit));
+        }
         if (mHoursOnes != null) {
             mHoursOnes.setText(String.format("%d", hoursOnesDigit));
         }
@@ -134,5 +176,9 @@ public class HmsView extends LinearLayout {
         if (mSecondsOnes != null) {
             mSecondsOnes.setText(String.format("%d", secondsOnesDigit));
         }
+    }
+
+    public void setHourMinutesOnly(boolean hourMinutesOnly) {
+        this.hourMinutesOnly = hourMinutesOnly;
     }
 }

--- a/library/src/main/res/layout/hms_picker_view.xml
+++ b/library/src/main/res/layout/hms_picker_view.xml
@@ -20,6 +20,14 @@
                 android:baselineAligned="false"
                 android:gravity="top">
             <com.codetroopers.betterpickers.widget.ZeroTopPaddingTextView
+                android:id="@+id/hours_tens"
+                android:singleLine="true"
+                android:ellipsize="none"
+                style="@style/medium_bold_hms"
+                android:layout_height="wrap_content"
+                android:layout_width="wrap_content"
+                />
+            <com.codetroopers.betterpickers.widget.ZeroTopPaddingTextView
                     android:id="@+id/hours_ones"
                     android:singleLine="true"
                     android:ellipsize="none"

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -265,6 +265,14 @@
             </intent-filter>
         </activity>
         <activity
+            android:name=".activity.hmspicker.SampleHmsHourMinutesOnlyUsage"
+            android:label="HMS/Hour Minutes Only Usage">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="com.doomonafireball.betterpickers.sample.SAMPLE" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name=".activity.hmspicker.SampleHmsThemeCustom"
             android:label="HMS/Theme Custom">
             <intent-filter>

--- a/sample/src/main/java/com/codetroopers/betterpickers/sample/activity/hmspicker/SampleHmsHourMinutesOnlyUsage.java
+++ b/sample/src/main/java/com/codetroopers/betterpickers/sample/activity/hmspicker/SampleHmsHourMinutesOnlyUsage.java
@@ -1,0 +1,46 @@
+package com.codetroopers.betterpickers.sample.activity.hmspicker;
+
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
+import android.widget.TextView;
+
+import com.codetroopers.betterpickers.hmspicker.HmsPickerBuilder;
+import com.codetroopers.betterpickers.hmspicker.HmsPickerDialogFragment;
+import com.codetroopers.betterpickers.sample.R;
+import com.codetroopers.betterpickers.sample.activity.BaseSampleActivity;
+
+/**
+ * User: derek Date: 3/17/13 Time: 3:59 PM
+ */
+public class SampleHmsHourMinutesOnlyUsage extends BaseSampleActivity implements HmsPickerDialogFragment.HmsPickerDialogHandler {
+
+    private TextView mResultTextView;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.text_and_button);
+
+        mResultTextView = (TextView) findViewById(R.id.text);
+        Button button = (Button) findViewById(R.id.button);
+
+        mResultTextView.setText(R.string.no_value);
+        button.setText(R.string.hms_picker_set);
+        button.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                HmsPickerBuilder hpb = new HmsPickerBuilder()
+                        .setHourMinutesOnly(true)
+                        .setFragmentManager(getSupportFragmentManager())
+                        .setStyleResId(R.style.BetterPickersDialogFragment);
+                hpb.show();
+            }
+        });
+    }
+
+    @Override
+    public void onDialogHmsSet(int reference, int hours, int minutes, int seconds) {
+        mResultTextView.setText(getString(R.string.hms_picker_result_value_multiline, hours, minutes, seconds));
+    }
+}


### PR DESCRIPTION
Hi,

In some cases I want my users to only pick hours and minutes. So I created a builder option that fulfills my requirement. I created a sample activity in the sample app: SampleHmsHourMinutesOnlyUsage

Please review and merge (If it is good enough).

Greetings,
paxxux
