### PR TITLE
Fixed leading zeroes issue in HMS Picker

### DIFF
--- a/library/src/main/java/com/codetroopers/betterpickers/hmspicker/HmsPicker.java
+++ b/library/src/main/java/com/codetroopers/betterpickers/hmspicker/HmsPicker.java
@@ -276,7 +276,7 @@ public class HmsPicker extends LinearLayout implements Button.OnClickListener, B
     }
 
     private void addClickedNumber(int val) {
-        if (mInputPointer < mInputSize - 1) {
+        if (mInputPointer < mInputSize - 1 && !(mInputPointer == -1 && val == 0)) {
             for (int i = mInputPointer; i >= 0; i--) {
                 mInput[i + 1] = mInput[i];
             }


### PR DESCRIPTION
Leading zeroes should be ignored, since they do not change the result, 
and they should especially not block further input.

This checks if there has been no input yet, and if so, it checks if the entered number is a zero, and if both are true, it ignores the input.
