### PR TITLE
Add last day of month option within recurrence picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ button.setOnClickListener(new View.OnClickListener() {
         bundle.putString(RecurrencePickerDialogFragment.BUNDLE_TIME_ZONE, time.timezone);
         bundle.putString(RecurrencePickerDialogFragment.BUNDLE_RRULE, mRrule);
         bundle.putBoolean(RecurrencePickerDialogFragment.BUNDLE_HIDE_SWITCH_BUTTON, true);
+        bundle.putBoolean(RecurrencePickerDialogFragment.BUNDLE_SHOW_MONTH_LAST_DAY, false);
         
         RecurrencePickerDialogFragment rpd = new RecurrencePickerDialogFragment();
         rpd.setArguments(bundle);

--- a/library/src/main/java/com/codetroopers/betterpickers/recurrencepicker/EventRecurrenceFormatter.java
+++ b/library/src/main/java/com/codetroopers/betterpickers/recurrencepicker/EventRecurrenceFormatter.java
@@ -111,6 +111,8 @@ public class EventRecurrenceFormatter {
                         dayNumber = 5;
                     }
                     details = mMonthRepeatByDayOfWeekStrs[weekday][dayNumber - 1];
+                } else if(recurrence.bymonthday != null) {
+                    details = r.getString(R.string.monthly_last_day);
                 }
                 return r.getQuantityString(R.plurals.monthly, interval, interval, details) + endString;
             }

--- a/library/src/main/res/layout/recurrencepicker.xml
+++ b/library/src/main/res/layout/recurrencepicker.xml
@@ -108,7 +108,7 @@
                             android:paddingRight="4dp"
                             android:selectAllOnFocus="true"
                             android:singleLine="true"
-                            android:textSize="15sp"></EditText>
+                            android:textSize="15sp" />
 
                         <TextView
                             android:id="@+id/intervalPostText"
@@ -181,6 +181,13 @@
                             style="@style/TextAppearance.RecurrencePickerStyle"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content" />
+
+                        <RadioButton
+                            android:id="@+id/repeatMonthlyByLastDayOfMonth"
+                            style="@style/TextAppearance.RecurrencePickerStyle"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/recurrence_month_pattern_by_last"/>
                     </RadioGroup>
 
                     <LinearLayout

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -90,6 +90,9 @@
     <!-- Repeat an monthly event on the same day of every month [CHAR LIMIT=20] -->
     <string name="recurrence_month_pattern_by_day">on the same day each month</string>
 
+    <!-- Repeat a monthly event on the last day of every month [CHAR LIMIT=20] -->
+    <string name="recurrence_month_pattern_by_last">on the last day each month</string>
+
     <!-- Description of the selected marker for accessibility support [CHAR LIMIT = NONE]-->
     <string name="acessibility_recurrence_choose_end_date_description">change end date</string>
 
@@ -183,6 +186,7 @@
     <!-- The common portion of a string describing how often an event repeats,
          example: 'Monthly (on day 2)' -->
     <string name="monthly">Monthly</string>
+    <string name="monthly_last_day">on the last day</string>
     <plurals name="monthly">
         <item quantity="one">Monthly <xliff:g id="days_of_month">%2$s</xliff:g></item>
         <item quantity="other">Every <xliff:g id="number">%1$d</xliff:g> months <xliff:g id="days_of_month">%2$s</xliff:g></item>

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -488,6 +488,14 @@
             </intent-filter>
         </activity>
         <activity
+            android:name="com.codetroopers.betterpickers.sample.activity.recurrencepicker.SampleRecurrenceMonthLast"
+            android:label="Recurrence/Last Day of Month">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="com.doomonafireball.betterpickers.sample.SAMPLE" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name=".activity.timezonepicker.SampleTimeZoneBasicUsage"
             android:label="Time Zone/Basic Usage">
             <intent-filter>

--- a/sample/src/main/java/com/codetroopers/betterpickers/sample/activity/recurrencepicker/SampleRecurrenceMonthLast.java
+++ b/sample/src/main/java/com/codetroopers/betterpickers/sample/activity/recurrencepicker/SampleRecurrenceMonthLast.java
@@ -16,7 +16,7 @@ import com.codetroopers.betterpickers.sample.R;
 import com.codetroopers.betterpickers.sample.activity.BaseSampleActivity;
 
 /**
- * User: killtheidols Date: 9/1/16 Time: 11:08 PM
+ * User: liamcottam Date: 9/1/16 Time: 11:08 PM
  */
 public class SampleRecurrenceMonthLast extends BaseSampleActivity
         implements RecurrencePickerDialogFragment.OnRecurrenceSetListener {

--- a/sample/src/main/java/com/codetroopers/betterpickers/sample/activity/recurrencepicker/SampleRecurrenceMonthLast.java
+++ b/sample/src/main/java/com/codetroopers/betterpickers/sample/activity/recurrencepicker/SampleRecurrenceMonthLast.java
@@ -1,0 +1,97 @@
+package com.codetroopers.betterpickers.sample.activity.recurrencepicker;
+
+import android.content.res.Resources;
+import android.os.Bundle;
+import android.support.v4.app.FragmentManager;
+import android.text.TextUtils;
+import android.text.format.Time;
+import android.view.View;
+import android.widget.Button;
+import android.widget.TextView;
+
+import com.codetroopers.betterpickers.recurrencepicker.EventRecurrence;
+import com.codetroopers.betterpickers.recurrencepicker.EventRecurrenceFormatter;
+import com.codetroopers.betterpickers.recurrencepicker.RecurrencePickerDialogFragment;
+import com.codetroopers.betterpickers.sample.R;
+import com.codetroopers.betterpickers.sample.activity.BaseSampleActivity;
+
+/**
+ * User: killtheidols Date: 9/1/16 Time: 11:08 PM
+ */
+public class SampleRecurrenceMonthLast extends BaseSampleActivity
+        implements RecurrencePickerDialogFragment.OnRecurrenceSetListener {
+
+    private static final String FRAG_TAG_RECUR_PICKER = "recurrencePickerDialogFragment";
+    private TextView mResultTextView;
+    private EventRecurrence mEventRecurrence = new EventRecurrence();
+    private String mRrule;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.text_and_button);
+
+        mResultTextView = (TextView) findViewById(R.id.text);
+        Button button = (Button) findViewById(R.id.button);
+
+        mResultTextView.setText(R.string.no_value);
+        button.setText(R.string.recurrence_picker_set);
+        button.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                FragmentManager fm = getSupportFragmentManager();
+                Bundle bundle = new Bundle();
+                Time time = new Time();
+                time.setToNow();
+                bundle.putLong(RecurrencePickerDialogFragment.BUNDLE_START_TIME_MILLIS, time.toMillis(false));
+                bundle.putString(RecurrencePickerDialogFragment.BUNDLE_TIME_ZONE, time.timezone);
+                bundle.putBoolean(RecurrencePickerDialogFragment.BUNDLE_SHOW_MONTH_LAST_DAY, true);
+
+                // may be more efficient to serialize and pass in EventRecurrence
+                bundle.putString(RecurrencePickerDialogFragment.BUNDLE_RRULE, mRrule);
+
+                RecurrencePickerDialogFragment rpd = (RecurrencePickerDialogFragment) fm.findFragmentByTag(
+                        FRAG_TAG_RECUR_PICKER);
+                if (rpd != null) {
+                    rpd.dismiss();
+                }
+                rpd = new RecurrencePickerDialogFragment();
+                rpd.setArguments(bundle);
+                rpd.setOnRecurrenceSetListener(SampleRecurrenceMonthLast.this);
+                rpd.show(fm, FRAG_TAG_RECUR_PICKER);
+            }
+        });
+    }
+
+    @Override
+    public void onRecurrenceSet(String rrule) {
+        mRrule = rrule;
+        if (mRrule != null) {
+            mEventRecurrence = new EventRecurrence();
+            mEventRecurrence.parse(mRrule);
+        }
+        populateRepeats();
+    }
+
+    @Override
+    public void onResume() {
+        // Example of reattaching to the fragment
+        super.onResume();
+        RecurrencePickerDialogFragment rpd = (RecurrencePickerDialogFragment) getSupportFragmentManager().findFragmentByTag(
+                FRAG_TAG_RECUR_PICKER);
+        if (rpd != null) {
+            rpd.setOnRecurrenceSetListener(this);
+        }
+    }
+
+    private void populateRepeats() {
+        Resources r = getResources();
+        String repeatString = "";
+        boolean enabled;
+        if (!TextUtils.isEmpty(mRrule)) {
+            repeatString = EventRecurrenceFormatter.getRepeatString(this, r, mEventRecurrence, true);
+        }
+
+        mResultTextView.setText(mRrule + "\n" + repeatString);
+    }
+}


### PR DESCRIPTION
I'm unsure about the WKST parameter so any additional input will help.

The option is enabled via the BUNDLE_SHOW_MONTH_LAST_DAY bool so it will not affect anything else by default.

I'm using -1 in  BYMONTHDAY to signify the last day of month as specified within RFC 2445 section 4.3.10:

The BYMONTHDAY rule part specifies a COMMA character (ASCII decimal
44) separated list of days of the month. Valid values are 1 to 31 or
-31 to -1. For example, -10 represents the tenth to the last day of
the month.
