### PR TITLE
Added HMSPicker hour minute only option #2

### DIFF
--- a/library/src/main/java/com/codetroopers/betterpickers/hmspicker/HmsPicker.java
+++ b/library/src/main/java/com/codetroopers/betterpickers/hmspicker/HmsPicker.java
@@ -45,6 +45,8 @@ public class HmsPicker extends LinearLayout implements Button.OnClickListener, B
     public static final int SIGN_POSITIVE = 0;
     public static final int SIGN_NEGATIVE = 1;
 
+    private boolean mHourMinutesOnly;
+
     /**
      * Instantiates an HmsPicker object
      *
@@ -119,7 +121,7 @@ public class HmsPicker extends LinearLayout implements Button.OnClickListener, B
             mMinutesLabel.setTextColor(mTextColor);
             mMinutesLabel.setBackgroundResource(mKeyBackgroundResId);
         }
-        if (mSecondsLabel != null) {
+        if (mSecondsLabel != null && !mHourMinutesOnly) {
             mSecondsLabel.setTextColor(mTextColor);
             mSecondsLabel.setBackgroundResource(mKeyBackgroundResId);
         }
@@ -129,6 +131,10 @@ public class HmsPicker extends LinearLayout implements Button.OnClickListener, B
         }
         if (mEnteredHms != null) {
             mEnteredHms.setTheme(mTheme);
+
+            if(mHourMinutesOnly) {
+                mEnteredHms.setHourMinutesOnly(true);
+            }
         }
         if (mLeft != null) {
             mLeft.setTextColor(mTextColor);
@@ -272,7 +278,11 @@ public class HmsPicker extends LinearLayout implements Button.OnClickListener, B
      * Hide digit by passing -2 (for highest hours digit only);
      */
     protected void updateHms() {
-        mEnteredHms.setTime(isNegative(), mInput[4], mInput[3], mInput[2], mInput[1], mInput[0]);
+        if(mHourMinutesOnly) {
+            mEnteredHms.setTime(isNegative(), mInput[3], mInput[2], mInput[1], mInput[0]);
+        } else {
+            mEnteredHms.setTime(isNegative(), mInput[4], mInput[3], mInput[2], mInput[1], mInput[0]);
+        }
     }
 
     private void addClickedNumber(int val) {
@@ -318,8 +328,11 @@ public class HmsPicker extends LinearLayout implements Button.OnClickListener, B
      * @return the inputted hours
      */
     public int getHours() {
-        int hours = mInput[4];
-        return hours;
+        if(mHourMinutesOnly){
+            return mInput[3] * 10 + mInput[2];
+        } else {
+            return mInput[4];
+        }
     }
 
     /**
@@ -328,7 +341,11 @@ public class HmsPicker extends LinearLayout implements Button.OnClickListener, B
      * @return the inputted minutes
      */
     public int getMinutes() {
-        return mInput[3] * 10 + mInput[2];
+        if(mHourMinutesOnly){
+            return mInput[1] * 10 + mInput[0];
+        } else {
+            return mInput[3] * 10 + mInput[2];
+        }
     }
 
     /**
@@ -337,7 +354,11 @@ public class HmsPicker extends LinearLayout implements Button.OnClickListener, B
      * @return the inputted seconds
      */
     public int getSeconds() {
-        return mInput[1] * 10 + mInput[0];
+        if(mHourMinutesOnly){
+            return 0;
+        } else {
+            return mInput[1] * 10 + mInput[0];
+        }
     }
 
     /**
@@ -359,13 +380,20 @@ public class HmsPicker extends LinearLayout implements Button.OnClickListener, B
      * @param seconds the input seconds value
      */
     public void setTime(int hours, int minutes, int seconds) {
-        mInput[4] = hours;
-        mInput[3] = minutes / 10;
-        mInput[2] = minutes % 10;
-        mInput[1] = seconds / 10;
-        mInput[0] = seconds % 10;
+        if(mHourMinutesOnly) {
+            mInput[3] = hours / 10;
+            mInput[2] = hours % 10;
+            mInput[1] = minutes / 10;
+            mInput[0] = minutes % 10;
+        } else {
+            mInput[4] = hours;
+            mInput[3] = minutes / 10;
+            mInput[2] = minutes % 10;
+            mInput[1] = seconds / 10;
+            mInput[0] = seconds % 10;
+        }
 
-        for (int i = 4; i >= 0; i--) {
+        for (int i=mInputSize - 1; i>=0; i--) {
             if (mInput[i] > 0) {
                 mInputPointer = i;
                 break;
@@ -447,11 +475,24 @@ public class HmsPicker extends LinearLayout implements Button.OnClickListener, B
      * @return an int representing the time in seconds
      */
     public int getTime() {
-        return mInput[4] * 3600 + mInput[3] * 600 + mInput[2] * 60 + mInput[1] * 10 + mInput[0];
+        if(mHourMinutesOnly) {
+            return mInput[3] * 36_000 +  mInput[2] * 3600 + mInput[1] * 600 + mInput[0] * 60;
+        } else {
+            return mInput[4] * 3600 + mInput[3] * 600 + mInput[2] * 60 + mInput[1] * 10 + mInput[0];
+        }
     }
 
     public void saveEntryState(Bundle outState, String key) {
         outState.putIntArray(key, mInput);
+    }
+    
+    public void setHourMinutesOnly(boolean mHourMinutesOnly) {
+        this.mHourMinutesOnly = mHourMinutesOnly;
+        if(mHourMinutesOnly) {
+            mInputSize = 4;
+            mInput = new int[mInputSize];
+            restyleViews();
+        }
     }
 
     public void restoreEntryState(Bundle inState, String key) {

--- a/library/src/main/java/com/codetroopers/betterpickers/hmspicker/HmsPickerBuilder.java
+++ b/library/src/main/java/com/codetroopers/betterpickers/hmspicker/HmsPickerBuilder.java
@@ -25,6 +25,8 @@ public class HmsPickerBuilder {
     private Integer plusMinusVisibility;
     private OnDialogDismissListener mOnDismissListener;
 
+    private Boolean mHourMinutesOnly;
+
     /**
      * Set the visibility of the +/- button. This takes an int corresponding to Android's View.VISIBLE, View.INVISIBLE,
      * or View.GONE.  When using View.INVISIBLE, the +/- button will still be present in the layout but be
@@ -39,6 +41,14 @@ public class HmsPickerBuilder {
         return this;
     }
 
+    /**
+     * Shows only the hours and minutes.
+     * @param hourMinutesOnly if True shows only hours and minutes. False by default.
+     */
+    public HmsPickerBuilder setHourMinutesOnly(boolean hourMinutesOnly){
+        this.mHourMinutesOnly = hourMinutesOnly;
+        return this;
+    }
 
     /**
      * Attach a FragmentManager. This is required for creation of the Fragment.
@@ -165,7 +175,8 @@ public class HmsPickerBuilder {
         }
         ft.addToBackStack(null);
 
-        final HmsPickerDialogFragment fragment = HmsPickerDialogFragment.newInstance(mReference, styleResId, plusMinusVisibility);
+        final HmsPickerDialogFragment fragment = HmsPickerDialogFragment.newInstance(mReference, styleResId, plusMinusVisibility,
+                mHourMinutesOnly);
         if (targetFragment != null) {
             fragment.setTargetFragment(targetFragment, 0);
         }

--- a/library/src/main/java/com/codetroopers/betterpickers/hmspicker/HmsPickerDialogFragment.java
+++ b/library/src/main/java/com/codetroopers/betterpickers/hmspicker/HmsPickerDialogFragment.java
@@ -25,6 +25,7 @@ public class HmsPickerDialogFragment extends DialogFragment {
     private static final String REFERENCE_KEY = "HmsPickerDialogFragment_ReferenceKey";
     private static final String THEME_RES_ID_KEY = "HmsPickerDialogFragment_ThemeResIdKey";
     private static final String PLUS_MINUS_VISIBILITY_KEY = "HmsPickerDialogFragment_PlusMinusVisibilityKey";
+    private static final String HOUR_MINUTES_ONLY_KEY = "HmsPickerDialogFragment_HourMinutesOnly";
 
     private HmsPicker mPicker;
 
@@ -36,6 +37,7 @@ public class HmsPickerDialogFragment extends DialogFragment {
     private int mHours;
     private int mMinutes;
     private int mSeconds;
+    private boolean mHourMinutesOnly = false;
     private int mPlusMinusVisibility = View.INVISIBLE;
     private OnDialogDismissListener mDismissCallback;
 
@@ -46,13 +48,17 @@ public class HmsPickerDialogFragment extends DialogFragment {
      * @param themeResId the style resource ID for theming
      * @return a Picker!
      */
-    public static HmsPickerDialogFragment newInstance(int reference, int themeResId, Integer plusMinusVisibility) {
+    public static HmsPickerDialogFragment newInstance(int reference, int themeResId, Integer plusMinusVisibility,
+                                                      Boolean hourMinutesOnly) {
         final HmsPickerDialogFragment frag = new HmsPickerDialogFragment();
         Bundle args = new Bundle();
         args.putInt(REFERENCE_KEY, reference);
         args.putInt(THEME_RES_ID_KEY, themeResId);
         if (plusMinusVisibility != null) {
             args.putInt(PLUS_MINUS_VISIBILITY_KEY, plusMinusVisibility);
+        }
+        if(hourMinutesOnly != null){
+            args.putBoolean(HOUR_MINUTES_ONLY_KEY, hourMinutesOnly);
         }
         frag.setArguments(args);
         return frag;
@@ -76,6 +82,9 @@ public class HmsPickerDialogFragment extends DialogFragment {
         }
         if (args != null && args.containsKey(PLUS_MINUS_VISIBILITY_KEY)) {
             mPlusMinusVisibility = args.getInt(PLUS_MINUS_VISIBILITY_KEY);
+        }
+        if(args != null && args.containsKey(HOUR_MINUTES_ONLY_KEY)){
+            mHourMinutesOnly = args.getBoolean(HOUR_MINUTES_ONLY_KEY);
         }
 
         setStyle(DialogFragment.STYLE_NO_TITLE, 0);
@@ -138,6 +147,7 @@ public class HmsPickerDialogFragment extends DialogFragment {
         mPicker.setTime(mHours, mMinutes, mSeconds);
         mPicker.setTheme(mTheme);
         mPicker.setPlusMinusVisibility(mPlusMinusVisibility);
+        mPicker.setHourMinutesOnly(mHourMinutesOnly);
 
         getDialog().getWindow().setBackgroundDrawableResource(mDialogBackgroundResId);
 

--- a/library/src/main/java/com/codetroopers/betterpickers/hmspicker/HmsView.java
+++ b/library/src/main/java/com/codetroopers/betterpickers/hmspicker/HmsView.java
@@ -13,12 +13,13 @@ import com.codetroopers.betterpickers.widget.ZeroTopPaddingTextView;
 
 public class HmsView extends LinearLayout {
 
-    private ZeroTopPaddingTextView mHoursOnes;
+    private ZeroTopPaddingTextView mHoursOnes, mHoursTens;
     private ZeroTopPaddingTextView mMinutesOnes, mMinutesTens;
-    private ZeroTopPaddingTextView mSecondsOnes, mSecondsTens;
+    private ZeroTopPaddingTextView mSecondsOnes, mSecondsTens, mSecondsLabel;
     private final Typeface mAndroidClockMonoThin;
     private Typeface mOriginalHoursTypeface;
     private ZeroTopPaddingTextView mMinusLabel;
+    private boolean hourMinutesOnly = false;
 
     private ColorStateList mTextColor;
 
@@ -63,6 +64,9 @@ public class HmsView extends LinearLayout {
     }
 
     private void restyleViews() {
+        if (mHoursTens != null) {
+            mHoursTens.setTextColor(mTextColor);
+        }
         if (mHoursOnes != null) {
             mHoursOnes.setTextColor(mTextColor);
         }
@@ -87,31 +91,61 @@ public class HmsView extends LinearLayout {
     protected void onFinishInflate() {
         super.onFinishInflate();
 
+        mHoursTens = (ZeroTopPaddingTextView) findViewById(R.id.hours_tens);
         mHoursOnes = (ZeroTopPaddingTextView) findViewById(R.id.hours_ones);
         mMinutesTens = (ZeroTopPaddingTextView) findViewById(R.id.minutes_tens);
         mMinutesOnes = (ZeroTopPaddingTextView) findViewById(R.id.minutes_ones);
         mSecondsTens = (ZeroTopPaddingTextView) findViewById(R.id.seconds_tens);
         mSecondsOnes = (ZeroTopPaddingTextView) findViewById(R.id.seconds_ones);
         mMinusLabel = (ZeroTopPaddingTextView) findViewById(R.id.minus_label);
+        mSecondsLabel = (ZeroTopPaddingTextView) findViewById(R.id.seconds_label);
 
+        onUpdateViewsVisibility();
+    }
+
+    private void onUpdateViewsVisibility() {
+        if (mHoursTens != null && !hourMinutesOnly) {
+            mHoursTens.setVisibility(GONE);
+        }
         if (mHoursOnes != null) {
             mOriginalHoursTypeface = mHoursOnes.getTypeface();
             mHoursOnes.updatePaddingForBoldDate();
         }
-        if (mMinutesTens != null) {
+        if (mMinutesTens != null && !hourMinutesOnly) {
             mMinutesTens.updatePaddingForBoldDate();
         }
-        if (mMinutesOnes != null) {
+        if (mMinutesOnes != null && !hourMinutesOnly) {
             mMinutesOnes.updatePaddingForBoldDate();
         }
         // Set the lowest time unit with thin font (excluding hundredths)
-        if (mSecondsTens != null) {
+        if (mSecondsTens != null && !hourMinutesOnly) {
             mSecondsTens.setTypeface(mAndroidClockMonoThin);
             mSecondsTens.updatePadding();
         }
-        if (mSecondsOnes != null) {
+        if (mSecondsOnes != null && !hourMinutesOnly) {
             mSecondsOnes.setTypeface(mAndroidClockMonoThin);
             mSecondsOnes.updatePadding();
+        }
+        if (mHoursTens != null && hourMinutesOnly) {
+             mHoursTens.updatePaddingForBoldDate();
+             mHoursTens.setVisibility(VISIBLE);
+        }
+        if (mMinutesTens != null && hourMinutesOnly) {
+             mMinutesTens.setTypeface(mAndroidClockMonoThin);
+             mMinutesTens.updatePadding();
+        }
+        if (mMinutesOnes != null && hourMinutesOnly) {
+             mMinutesOnes.setTypeface(mAndroidClockMonoThin);
+             mMinutesOnes.updatePadding();
+        }
+        if (mSecondsTens != null && hourMinutesOnly) {
+             mSecondsTens.setVisibility(GONE);
+        }
+        if (mSecondsOnes != null && hourMinutesOnly) {
+             mSecondsOnes.setVisibility(GONE);
+        }
+        if(mSecondsLabel != null && hourMinutesOnly){
+             mSecondsLabel.setVisibility(GONE);
         }
     }
 
@@ -129,7 +163,20 @@ public class HmsView extends LinearLayout {
         setTime(false, hoursOnesDigit, minutesTensDigit, minutesOnesDigit, secondsTensDigit, secondsOnesDigit);
     }
 
-    public void setTime(boolean isNegative, int hoursOnesDigit, int minutesTensDigit, int minutesOnesDigit, int secondsTensDigit,
+    public void setTime(boolean isNegative, int hoursTensDigit,  int hoursOnesDigit, int minutesTensDigit,
+                        int minutesOnesDigit) {
+        if (mHoursTens != null){
+            mHoursTens.setText(String.format("%d", hoursTensDigit));
+        }
+        setTime(isNegative, hoursOnesDigit, minutesTensDigit, minutesOnesDigit, 0, 0);
+    }
+
+    public void setHourMinutesOnly(boolean hourMinutesOnly) {
+        this.hourMinutesOnly = hourMinutesOnly;
+        onUpdateViewsVisibility();
+    }
+
+    public void setTime(boolean isNegative,  int hoursOnesDigit, int minutesTensDigit, int minutesOnesDigit, int secondsTensDigit,
             int secondsOnesDigit) {
 
         mMinusLabel.setVisibility(isNegative ? View.VISIBLE : View.GONE);

--- a/library/src/main/res/layout/hms_picker_view.xml
+++ b/library/src/main/res/layout/hms_picker_view.xml
@@ -20,6 +20,14 @@
                 android:baselineAligned="false"
                 android:gravity="top">
             <com.codetroopers.betterpickers.widget.ZeroTopPaddingTextView
+                android:id="@+id/hours_tens"
+                android:singleLine="true"
+                android:ellipsize="none"
+                style="@style/medium_bold_hms"
+                android:layout_height="wrap_content"
+                android:layout_width="wrap_content"
+                />
+            <com.codetroopers.betterpickers.widget.ZeroTopPaddingTextView
                     android:id="@+id/hours_ones"
                     android:singleLine="true"
                     android:ellipsize="none"

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -299,6 +299,14 @@
             </intent-filter>
         </activity>
         <activity
+            android:name=".activity.hmspicker.SampleHmsHourMinutesOnlyUsage"
+            android:label="HMS/Hour Minutes Only Usage">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="com.doomonafireball.betterpickers.sample.SAMPLE" />
+            </intent-filter>
+        </activity>
+        <activity
             android:name=".activity.hmspicker.SampleHmsThemeCustom"
             android:label="HMS/Theme Custom">
             <intent-filter>

--- a/sample/src/main/java/com/codetroopers/betterpickers/sample/activity/hmspicker/SampleHmsHourMinutesOnlyUsage.java
+++ b/sample/src/main/java/com/codetroopers/betterpickers/sample/activity/hmspicker/SampleHmsHourMinutesOnlyUsage.java
@@ -1,0 +1,48 @@
+package com.codetroopers.betterpickers.sample.activity.hmspicker;
+
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
+import android.widget.TextView;
+
+import com.codetroopers.betterpickers.hmspicker.HmsPickerBuilder;
+import com.codetroopers.betterpickers.hmspicker.HmsPickerDialogFragment;
+import com.codetroopers.betterpickers.sample.R;
+import com.codetroopers.betterpickers.sample.activity.BaseSampleActivity;
+
+/**
+ * User: derek Date: 3/17/13 Time: 3:59 PM
+ */
+public class SampleHmsHourMinutesOnlyUsage extends BaseSampleActivity implements HmsPickerDialogFragment.HmsPickerDialogHandlerV2 {
+
+    private TextView mResultTextView;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.text_and_button);
+
+        mResultTextView = (TextView) findViewById(R.id.text);
+        Button button = (Button) findViewById(R.id.button);
+
+        mResultTextView.setText(R.string.no_value);
+        button.setText(R.string.hms_picker_set);
+        button.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                HmsPickerBuilder hpb = new HmsPickerBuilder()
+                        .setHourMinutesOnly(true)
+                        .setFragmentManager(getSupportFragmentManager())
+                        .setStyleResId(R.style.BetterPickersDialogFragment);
+                hpb.show();
+            }
+        });
+    }
+
+    @Override
+    public void onDialogHmsSet(int reference, boolean isNegative, int hours, int minutes, int seconds) {
+        mResultTextView.setText(getString(R.string.hms_picker_result_value_multiline, String.valueOf(hours),
+                String.valueOf(minutes), String.valueOf(seconds), isNegative));
+    }
+
+}


### PR DESCRIPTION
This is the same PR that https://github.com/code-troopers/android-betterpickers/pull/279 I just fixed the conflicts that we had there. Since the API updated a couple of times since the previous PR, we had a couple of conflicts with the isNegative option.

This feature is really useful on my App, so I'd appreciate having it in the library's repo rather than having to use my own forked version. If you see anything wrong, just let me know.