### PR TITLE
Fixes bug #350

### DIFF
--- a/library/src/main/java/com/codetroopers/betterpickers/recurrencepicker/EventRecurrenceFormatter.java
+++ b/library/src/main/java/com/codetroopers/betterpickers/recurrencepicker/EventRecurrenceFormatter.java
@@ -110,7 +110,9 @@ public class EventRecurrenceFormatter {
                     if(dayNumber == RecurrencePickerDialogFragment.LAST_NTH_DAY_OF_WEEK){
                         dayNumber = 5;
                     }
-                    details = mMonthRepeatByDayOfWeekStrs[weekday][dayNumber - 1];
+                    if (dayNumber > 0) {
+                        details = mMonthRepeatByDayOfWeekStrs[weekday][dayNumber - 1];
+                    }
                 }
                 return r.getQuantityString(R.plurals.monthly, interval, interval, details) + endString;
             }


### PR DESCRIPTION
This solves bug #350

I did reproduce the error described by @Rx2TF which throws this exception:
`java.lang.ArrayIndexOutOfBoundsException: length=5; index=-1`

Looks like `EventRecurrence#parse()` method is leaving some garbage data in the `EventRecurrence#byday` field. This can be reproduced calling `parse()` two times, one with a weekly recurrence and then with a monthly recurrence; after this, the `byday` field keeps some data from the first call.

I didn't solve the root problem in `EventRecurrence` class because it looks like I can easily break something there.